### PR TITLE
Upgrade model to GPT2 and dataset to tiiuae/falcon-refinedweb

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ wandb login <your_wandb_api_key>
 Once you have installed this repo and attained your subnet via the instructions in the nested docs (staging, testing, or main) you can run the miner and validator with the following commands.
 ```bash
 # To run the miner
-python -m neurons/miner.py 
+python neurons/miner.py 
     --netuid <your netuid>  # Must be attained by following the instructions in the docs/running_on_*.md files
     --subtensor.chain_endpoint <your chain url>  # Must be attained by following the instructions in the docs/running_on_*.md files
     --wallet.name <your miner wallet> # Must be created using the bittensor-cli
@@ -36,7 +36,7 @@ python -m neurons/miner.py
     --dht.announce_ip <your device ip address>
 
 # To run the validator
-python -m neurons/validator.py 
+python neurons/validator.py 
     --netuid <your netuid> # Must be attained by following the instructions in the docs/running_on_*.md files
     --subtensor.chain_endpoint <your chain url> # Must be attained by following the instructions in the docs/running_on_*.md files
     --wallet.name <your validator wallet>  # Must be created using the bittensor-cli

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -135,16 +135,6 @@ class Miner(BaseMinerNeuron):
             state_averaging_compression=hivemind.Float16Compression(),
         )
 
-        load_state_from_peers_status = False
-        retries = 0
-        while load_state_from_peers_status is False:
-            try:
-                load_state_from_peers_status = self.opt.state_averager.load_state_from_peers()
-            except Exception as e:
-                bt.logging.error(f"Attempt {retries + 1} to write to the load state from peers failed: {e}")
-                retries += 1
-                bt.logging.error(f"Retrying ...")
-
         self.tokenizer = AutoTokenizer.from_pretrained(self.config.neuron.model_name)
         # Add the EOS token as PAD token to ensure our dataloader doesn't throw an error for sequences of unequal length
         self.tokenizer.pad_token = self.tokenizer.eos_token

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -147,7 +147,7 @@ class Miner(BaseMinerNeuron):
 
         # Init Wandb
         if not self.config.neuron.dont_wandb_log:
-            self.wandb = load_wandb(self.config, self.wallet)
+            self.wandb = load_wandb(self.config, self.wallet, "miner", str(self.dht.peer_id))
 
     # Define encoding function
     def encode(self, examples):

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -201,16 +201,13 @@ class Miner(BaseMinerNeuron):
 
         # Train data for one epoch
         for step, batch in enumerate(dataloader):
-            input_ids = batch["input_ids"].to(self.device)
-            attention_mask = batch["attention_mask"].to(self.device)
-            labels = input_ids.clone()
+
+            inputs = batch.to(self.device)
 
             self.opt.zero_grad()
 
             # Forward pass
-            outputs = self.model(
-                input_ids=input_ids, attention_mask=attention_mask, labels=labels
-            )
+            outputs = self.model(input_ids=inputs, labels=inputs)
             # Backward pass
             loss = outputs.loss
             if not self.config.neuron.dont_wandb_log:

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -132,6 +132,8 @@ class Miner(BaseMinerNeuron):
             matchmaking_time=15.0,  # when averaging parameters, gather peers in background for up to this many seconds
             averaging_timeout=60.0,  # give up on averaging if not successful in this many seconds
             verbose=False,  # print logs incessently
+            grad_compression=hivemind.Float16Compression(),
+            state_averaging_compression=hivemind.Float16Compression(),
         )
 
         self.tokenizer = AutoTokenizer.from_pretrained(self.config.neuron.model_name)

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -202,7 +202,6 @@ class Miner(BaseMinerNeuron):
 
         # Train data for one epoch
         for step, batch in enumerate(dataloader):
-
             inputs = batch.to(self.device)
 
             # Forward pass

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -126,7 +126,7 @@ class Miner(BaseMinerNeuron):
             scheduler=partial(
                 torch.optim.lr_scheduler.LambdaLR, lr_lambda=lambda t: 1.0 / max(1, t)
             ),
-            batch_size_per_step=self.config.neuron.local_batch_size_train,  # each call to opt.step adds this many samples towards the next epoch
+            batch_size_per_step=self.config.neuron.local_batch_size_train*self.config.neuron.local_gradient_accumilation_steps_train,  # each call to opt.step adds this many samples towards the next epoch
             target_batch_size=self.config.neuron.global_batch_size_train,  # after peers collectively process this many samples, average weights and begin the next epoch
             optimizer=opt,  # wrap the SGD optimizer defined above
             use_local_updates=True,  # perform optimizer steps with local gradients, average parameters in background

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -129,7 +129,7 @@ class Miner(BaseMinerNeuron):
             batch_size_per_step=self.config.neuron.local_batch_size_train,  # each call to opt.step adds this many samples towards the next epoch
             target_batch_size=self.config.neuron.global_batch_size_train,  # after peers collectively process this many samples, average weights and begin the next epoch
             optimizer=opt,  # wrap the SGD optimizer defined above
-            use_local_updates=False,  # perform optimizer steps with local gradients, average parameters in background
+            use_local_updates=True,  # perform optimizer steps with local gradients, average parameters in background
             matchmaking_time=15.0,  # when averaging parameters, gather peers in background for up to this many seconds
             averaging_timeout=600.0,  # give up on averaging if not successful in this many seconds
             verbose=False,  # print logs incessently

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -128,9 +128,9 @@ class Miner(BaseMinerNeuron):
             batch_size_per_step=self.config.neuron.local_batch_size_train,  # each call to opt.step adds this many samples towards the next epoch
             target_batch_size=self.config.neuron.global_batch_size_train,  # after peers collectively process this many samples, average weights and begin the next epoch
             optimizer=opt,  # wrap the SGD optimizer defined above
-            use_local_updates=True,  # perform optimizer steps with local gradients, average parameters in background
+            use_local_updates=False,  # perform optimizer steps with local gradients, average parameters in background
             matchmaking_time=15.0,  # when averaging parameters, gather peers in background for up to this many seconds
-            averaging_timeout=60.0,  # give up on averaging if not successful in this many seconds
+            averaging_timeout=600.0,  # give up on averaging if not successful in this many seconds
             verbose=False,  # print logs incessently
             grad_compression=hivemind.Float16Compression(),
             state_averaging_compression=hivemind.Float16Compression(),

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -123,9 +123,7 @@ class Miner(BaseMinerNeuron):
         self.opt = hivemind.Optimizer(
             dht=self.dht,  # use a DHT that is connected with other peers
             run_id=self.config.neuron.run_id,  # unique identifier of this collaborative run
-            scheduler=partial(
-                torch.optim.lr_scheduler.LambdaLR, lr_lambda=lambda t: 1.0 / max(1, t)
-            ),
+            scheduler=None,
             batch_size_per_step=self.config.neuron.local_batch_size_train*self.config.neuron.local_gradient_accumilation_steps_train,  # each call to opt.step adds this many samples towards the next epoch
             target_batch_size=self.config.neuron.global_batch_size_train,  # after peers collectively process this many samples, average weights and begin the next epoch
             optimizer=opt,  # wrap the SGD optimizer defined above

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -108,6 +108,7 @@ class Validator(BaseValidatorNeuron):
             allow_state_sharing=False,
             start=True,
             prefix=f"{self.config.neuron.run_id}_state_averager",
+            state_compression=hivemind.Float16Compression(),
             # **asdict(averager_args),
         )
         

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -113,7 +113,7 @@ class Validator(BaseValidatorNeuron):
             verbose=False,  # print logs incessently
             grad_compression=hivemind.Float16Compression(),
             state_averaging_compression=hivemind.Float16Compression(),
-            client_mode = True,
+            # client_mode = True,
         )
         
         # Get Current Epoch
@@ -173,7 +173,7 @@ class Validator(BaseValidatorNeuron):
                     initial_peers=[initial_peers_list[retries]],
                     announce_maddrs=announce_maddrs,
                     start=True,
-                    client_mode = True,
+                    # client_mode = True,
                 )
                 bt.logging.info(
                     f"Successfully initialised dht using initial_peer as {initial_peers_list[retries]}"

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -103,6 +103,9 @@ class Validator(BaseValidatorNeuron):
         self.opt = hivemind.Optimizer(
             dht=self.dht,  # use a DHT that is connected with other peers
             run_id=self.config.neuron.run_id,  # unique identifier of this collaborative run
+            scheduler=partial(
+                torch.optim.lr_scheduler.LambdaLR, lr_lambda=lambda t: 1.0 / max(1, t)
+            ),
             batch_size_per_step=self.config.neuron.local_batch_size_train,  # each call to opt.step adds this many samples towards the next epoch
             target_batch_size=self.config.neuron.global_batch_size_train,  # after peers collectively process this many samples, average weights and begin the next epoch
             optimizer=opt,  # wrap the SGD optimizer defined above

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -37,6 +37,7 @@ from template.base.validator import BaseValidatorNeuron
 from template.utils.misc import AsyncDendritePool, load_wandb
 from template.validator import forward
 from template.validator.validator_core import DatasetState, upload_checkpoint
+from bitarray import bitarray
 
 
 class Validator(BaseValidatorNeuron):
@@ -59,7 +60,7 @@ class Validator(BaseValidatorNeuron):
 
         # # Init Dataset
         dataset_length = 968000015
-        self.dataset_indices = [i for i in range(0, dataset_length)]
+        self.dataset_indices = bitarray(dataset_length)
         self.dataset_dict = dict()  # Init a dict to use as placeholder DHT
 
         self.dataset_common_state = DatasetState(

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -99,25 +99,20 @@ class Validator(BaseValidatorNeuron):
         self.tokenizer = AutoTokenizer.from_pretrained(self.config.neuron.model_name)
         self.tokenizer.pad_token = self.tokenizer.eos_token
 
-        opt = torch.optim.AdamW(self.model.parameters(), lr=self.config.neuron.lr)
-        self.opt = hivemind.Optimizer(
-            dht=self.dht,  # use a DHT that is connected with other peers
-            run_id=self.config.neuron.run_id,  # unique identifier of this collaborative run
+        # Init State Averager
+        self.state_averager = TrainingStateAverager(
+            dht=self.dht,
+            optimizer=partial(torch.optim.AdamW, lr=self.config.neuron.lr),
             scheduler=None,
-            batch_size_per_step=self.config.neuron.local_batch_size_train*self.config.neuron.local_gradient_accumilation_steps_train,  # each call to opt.step adds this many samples towards the next epoch
-            target_batch_size=self.config.neuron.global_batch_size_train,  # after peers collectively process this many samples, average weights and begin the next epoch
-            optimizer=opt,  # wrap the SGD optimizer defined above
-            use_local_updates=True,  # perform optimizer steps with local gradients, average parameters in background
-            matchmaking_time=15.0,  # when averaging parameters, gather peers in background for up to this many seconds
-            averaging_timeout=600.0,  # give up on averaging if not successful in this many seconds
-            verbose=False,  # print logs incessently
-            grad_compression=hivemind.Float16Compression(),
-            state_averaging_compression=hivemind.Float16Compression(),
-            # client_mode = True,
+            params=self.model.parameters(),
+            allow_state_sharing=False,
+            start=True,
+            prefix=f"{self.config.neuron.run_id}_state_averager",
+            # **asdict(averager_args),
         )
         
         # Get Current Epoch
-        self.current_epoch = self.opt.tracker.global_progress.epoch
+        self.current_epoch = 1 # Dummy fix need to swithc to self.opt.tracker.global_progress.epoch
         
         # Start Main Validation Loop
         bt.logging.info("Starting validator loop.")

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -58,19 +58,17 @@ class Validator(BaseValidatorNeuron):
         )
 
         # # Init Dataset
-        self.dataset = load_dataset(
-            self.config.neuron.dataset_name, "wikitext-2-v1", split="train"
-        )
-        self.dataset_indices = [i for i in range(0, len(self.dataset))]
+        dataset_length = 968000015
+        self.dataset_indices = [i for i in range(0, dataset_length)]
         self.dataset_dict = dict()  # Init a dict to use as placeholder DHT
+
         self.dataset_common_state = DatasetState(
             self.dataset_dict, self.dataset_indices, self.config.neuron.run_id
         )
-
+        
         # self.dataset_indices_list_test = self.dataset_common_state.get_dht("dataset_indices_train")
         # if self.dataset_indices_list_test is None:
         #     self.dataset_indices_list_test = self.dataset_common_state.get_dht("dataset_indices_test")
-
         self.dataset_indices_list_test = (
             self.dataset_common_state.get_dataset_indices_test(
                 self.config.neuron.local_batch_size_test
@@ -109,7 +107,7 @@ class Validator(BaseValidatorNeuron):
             allow_state_sharing=False,
             start=True,
             prefix=f"{self.config.neuron.run_id}_state_averager",
-            # **asdict(averager_args),
+            state_compression=hivemind.Float16Compression(),
         )
 
         # Start Main Validation Loop

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -111,6 +111,7 @@ class Validator(BaseValidatorNeuron):
             verbose=False,  # print logs incessently
             grad_compression=hivemind.Float16Compression(),
             state_averaging_compression=hivemind.Float16Compression(),
+            client_mode = True,
         )
         
         # Get Current Epoch

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -103,9 +103,7 @@ class Validator(BaseValidatorNeuron):
         self.opt = hivemind.Optimizer(
             dht=self.dht,  # use a DHT that is connected with other peers
             run_id=self.config.neuron.run_id,  # unique identifier of this collaborative run
-            scheduler=partial(
-                torch.optim.lr_scheduler.LambdaLR, lr_lambda=lambda t: 1.0 / max(1, t)
-            ),
+            scheduler=None,
             batch_size_per_step=self.config.neuron.local_batch_size_train*self.config.neuron.local_gradient_accumilation_steps_train,  # each call to opt.step adds this many samples towards the next epoch
             target_batch_size=self.config.neuron.global_batch_size_train,  # after peers collectively process this many samples, average weights and begin the next epoch
             optimizer=opt,  # wrap the SGD optimizer defined above

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -83,10 +83,11 @@ class Validator(BaseValidatorNeuron):
             # self.dataset_common_state.set_dht("step")
 
         # Init Loss
-        self.previous_loss = None
+        self.previous_loss = self.dataset_common_state.get_dht("loss")
         self.latest_upload = 0
         self.latest_weight_update = 0
         self.step = 0
+        self.global_step = self.dataset_common_state.get_dht("step")
 
         # Init device
         self.device = self.config.neuron.device
@@ -105,7 +106,7 @@ class Validator(BaseValidatorNeuron):
             batch_size_per_step=self.config.neuron.local_batch_size_train,  # each call to opt.step adds this many samples towards the next epoch
             target_batch_size=self.config.neuron.global_batch_size_train,  # after peers collectively process this many samples, average weights and begin the next epoch
             optimizer=opt,  # wrap the SGD optimizer defined above
-            use_local_updates=False,  # perform optimizer steps with local gradients, average parameters in background
+            use_local_updates=True,  # perform optimizer steps with local gradients, average parameters in background
             matchmaking_time=15.0,  # when averaging parameters, gather peers in background for up to this many seconds
             averaging_timeout=600.0,  # give up on averaging if not successful in this many seconds
             verbose=False,  # print logs incessently

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -106,7 +106,7 @@ class Validator(BaseValidatorNeuron):
             scheduler=partial(
                 torch.optim.lr_scheduler.LambdaLR, lr_lambda=lambda t: 1.0 / max(1, t)
             ),
-            batch_size_per_step=self.config.neuron.local_batch_size_train,  # each call to opt.step adds this many samples towards the next epoch
+            batch_size_per_step=self.config.neuron.local_batch_size_train*self.config.neuron.local_gradient_accumilation_steps_train,  # each call to opt.step adds this many samples towards the next epoch
             target_batch_size=self.config.neuron.global_batch_size_train,  # after peers collectively process this many samples, average weights and begin the next epoch
             optimizer=opt,  # wrap the SGD optimizer defined above
             use_local_updates=True,  # perform optimizer steps with local gradients, average parameters in background

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -52,7 +52,7 @@ class Validator(BaseValidatorNeuron):
 
         # Init Wandb
         if not self.config.neuron.dont_wandb_log:
-            self.wandb = load_wandb(self.config, self.wallet)
+            self.wandb = load_wandb(self.config, self.wallet, "validator", str(self.dht.peer_id))
 
         # Init Dendrite Pool
         self.dendrite_pool = AsyncDendritePool(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 bittensor
+bitarray==2.9.2
 datasets
 transformers
 hivemind

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ datasets
 transformers
 hivemind
 wandb
+bitarray

--- a/scripts/training_monitor.py
+++ b/scripts/training_monitor.py
@@ -16,7 +16,7 @@ parser.add_argument(
         "--global_batch_size_train",
         type=int,
         help="The hivemind global target_batch_size",
-        default=8000,
+        default=1600,
 )
 parser.add_argument(
     "--run_id",

--- a/scripts/training_monitor.py
+++ b/scripts/training_monitor.py
@@ -1,0 +1,33 @@
+import hivemind
+import argparse
+from time import sleep
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "--initial_peers",
+    type=str,
+    nargs="+",
+    help="The addresses for the DHT",
+    default=[
+        "/ip4/127.0.0.1/tcp/22162/p2p/12D3KooWGjNpqMSQaWudtrBseypWVRMccRiQAWzV1QoPzbki8fRs",
+    ],
+)
+parser.add_argument(
+        "--global_batch_size_train",
+        type=int,
+        help="The hivemind global target_batch_size",
+        default=8000,
+)
+parser.add_argument(
+    "--run_id",
+    type=str,
+    help="The DHT run_id",
+    default="s25_run_v3",
+)
+
+config = parser.parse_args()    
+dht = hivemind.DHT(initial_peers=config.initial_peers, start=True, client_mode = True)
+progress_tracker = hivemind.optim.progress_tracker.ProgressTracker(dht=dht, prefix=config.run_id, target_batch_size=config.global_batch_size_train, start = True)
+while True:
+    print(progress_tracker.global_progress)
+    sleep(10)

--- a/template/base/validator.py
+++ b/template/base/validator.py
@@ -117,7 +117,6 @@ class BaseValidatorNeuron(BaseNeuron):
             KeyboardInterrupt: If the miner is stopped by a manual interruption.
             Exception: For unforeseen errors during the miner's operation, which are logged for diagnosis.
         """
-
         # Check that validator is registered on the network.
         self.sync()
 

--- a/template/data/dataset.py
+++ b/template/data/dataset.py
@@ -56,7 +56,6 @@ class SubsetFalconLoader(IterableDataset):
         while attempt < self.retry_limit:
             try:
                 response = requests.get(self.base_url, params=self.params)
-                breakpoint()
                 response.raise_for_status()  # This will raise an HTTPError if the HTTP request returned an unsuccessful status code
 
                 for row in response.json()["rows"]:
@@ -78,7 +77,6 @@ class SubsetFalconLoader(IterableDataset):
                     raise
 
     def __iter__(self):
-        breakpoint()
         while len(self.buffer) >= self.sequence_length * self.batch_size:
             batch = []
             for _ in range(self.batch_size):
@@ -87,86 +85,17 @@ class SubsetFalconLoader(IterableDataset):
             yield torch.stack(batch)
 
     def __next__(self):
-        breakpoint()
         batch = []
         for _ in range(self.batch_size):
             batch.append(torch.tensor(self.buffer[: self.sequence_length]))
             self.buffer = self.buffer[self.sequence_length :]
         return torch.stack(batch)
 
-# class SubsetFalconLoader(IterableDataset):
-#     max_pages: int = 968000015
-
-#     def __init__(self, batch_size, sequence_length, pages: typing.List[int]):
-#         self.batch_size = batch_size
-#         self.sequence_length = sequence_length
-#         self.num_rows_per_page = 100
-#         self.tokenizer = tokenizer
-#         self.base_url = "https://datasets-server.huggingface.co/rows"
-#         self.params = {
-#             "dataset": "tiiuae/falcon-refinedweb",
-#             "config": "default",
-#             "split": "train",
-#         }
-#         self.pages = pages
-#         self.buffer = []
-#         self.retry_limit = 10  # Number of retries
-#         self.retry_delay = 5  # Seconds to wait between retries
-
-#         for page in self.pages:
-#             self.fetch_data_for_page(page)
-
-#     def fetch_data_for_page(self, page):
-#         self.params["offset"] = page
-#         self.params["limit"] = self.num_rows_per_page
-#         attempt = 0
-#         while attempt < self.retry_limit:
-#             try:
-#                 response = requests.get(self.base_url, params=self.params)
-#                 response.raise_for_status()  # This will raise an HTTPError if the HTTP request returned an unsuccessful status code
-#                 for row in response.json()["rows"]:
-#                     content = row["row"]["content"]
-#                     self.buffer += self.tokenizer(content, truncation=True)["input_ids"]
-#                     self.buffer += [self.tokenizer.eos_token_id]
-#                 break  # If the request was successful, break out of the retry loop
-#             except requests.exceptions.RequestException as e:
-#                 attempt += 1
-#                 bt.logging.warning(
-#                     f"Failed to fetch data, retrying. Attempt {attempt}/{self.retry_limit}"
-#                 )
-#                 if attempt < self.retry_limit:
-#                     time.sleep(self.retry_delay)  # Wait before the next retry
-#                 else:
-#                     bt.logging.error(
-#                         "Maximum retry limit reached. Unable to fetch data."
-#                     )
-#                     raise
-
-#     def __iter__(self):
-#         breakpoint()
-#         while len(self.buffer) >= self.sequence_length * self.batch_size:
-#             batch = []
-#             for _ in range(self.batch_size):
-#                 batch.append(torch.tensor(self.buffer[: self.sequence_length]))
-#                 self.buffer = self.buffer[self.sequence_length :]
-#             yield torch.stack(batch)
-
-#     def __next__(self):
-#         breakpoint()
-#         batch = []
-#         for _ in range(self.batch_size):
-#             batch.append(torch.tensor(self.buffer[: self.sequence_length]))
-#             self.buffer = self.buffer[self.sequence_length :]
-#         return torch.stack(batch)
-
 loader = SubsetFalconLoader(
     batch_size=10, sequence_length=1024, tokenizer = tokenizer, rows=[i for i in range(0,200)]
 )
 
-# loader = SubsetFalconLoader(
-#     batch_size=10, sequence_length=1024, pages=[1]
-# )
-
 for i, batch in enumerate(loader):
     print(i)
     print(batch)
+breakpoint()

--- a/template/data/dataset.py
+++ b/template/data/dataset.py
@@ -47,8 +47,6 @@ class SubsetFalconLoader(IterableDataset):
         self.retry_limit = 10  # Number of retries
         self.retry_delay = 5  # Seconds to wait between retries
         self.fetch_data_for_page(min(self.rows), len(self.rows))
-        # breakpoint()
-
     def fetch_data_for_page(self, offset, length):
         iterations = math.ceil(length/100)
         for iteration in range(iterations):
@@ -92,12 +90,3 @@ class SubsetFalconLoader(IterableDataset):
             batch.append(torch.tensor(self.buffer[: self.sequence_length]))
             self.buffer = self.buffer[self.sequence_length :]
         return torch.stack(batch)
-
-# loader = SubsetFalconLoader(
-#     batch_size=10, sequence_length=1024, tokenizer = tokenizer, rows=[i for i in range(0,200)]
-# )
-
-# for i, batch in enumerate(loader):
-#     print(i)
-#     print(batch)
-# breakpoint()

--- a/template/data/dataset.py
+++ b/template/data/dataset.py
@@ -1,0 +1,172 @@
+# The MIT License (MIT)
+# Copyright © 2023 Yuma Rao
+# Copyright © 2023 const
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the “Software”), to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+# the Software.
+
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+# THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+import torch
+import typing
+import requests
+import bittensor as bt
+from torch.utils.data import IterableDataset
+from transformers import AutoTokenizer
+import time
+
+model_name = "distilgpt2"
+tokenizer = AutoTokenizer.from_pretrained(model_name)
+tokenizer.pad_token = tokenizer.eos_token
+
+
+class SubsetFalconLoader(IterableDataset):
+    max_pages: int = 968000015
+
+    def __init__(self, batch_size, sequence_length, tokenizer, rows: typing.List[int]):
+        self.batch_size = batch_size
+        self.sequence_length = sequence_length
+        self.tokenizer = tokenizer
+        self.base_url = "https://datasets-server.huggingface.co/rows"
+        self.params = {
+            "dataset": "tiiuae/falcon-refinedweb",
+            "config": "default",
+            "split": "train",
+        }
+        self.rows = rows
+        self.buffer = []
+        self.retry_limit = 10  # Number of retries
+        self.retry_delay = 5  # Seconds to wait between retries
+        # breakpoint()
+        self.fetch_data_for_page(min(self.rows), len(self.rows))
+        # breakpoint()
+
+    def fetch_data_for_page(self, offset, length):
+        self.params["offset"] = offset
+        self.params["limit"] = length
+        attempt = 0
+        while attempt < self.retry_limit:
+            try:
+                response = requests.get(self.base_url, params=self.params)
+                breakpoint()
+                response.raise_for_status()  # This will raise an HTTPError if the HTTP request returned an unsuccessful status code
+
+                for row in response.json()["rows"]:
+                    content = row["row"]["content"]
+                    self.buffer += self.tokenizer(content, truncation=True)["input_ids"]
+                    self.buffer += [self.tokenizer.eos_token_id]
+                break  # If the request was successful, break out of the retry loop
+            except requests.exceptions.RequestException as e:
+                attempt += 1
+                bt.logging.warning(
+                    f"Failed to fetch data, retrying. Attempt {attempt}/{self.retry_limit}"
+                )
+                if attempt < self.retry_limit:
+                    time.sleep(self.retry_delay)  # Wait before the next retry
+                else:
+                    bt.logging.error(
+                        "Maximum retry limit reached. Unable to fetch data."
+                    )
+                    raise
+
+    def __iter__(self):
+        breakpoint()
+        while len(self.buffer) >= self.sequence_length * self.batch_size:
+            batch = []
+            for _ in range(self.batch_size):
+                batch.append(torch.tensor(self.buffer[: self.sequence_length]))
+                self.buffer = self.buffer[self.sequence_length :]
+            yield torch.stack(batch)
+
+    def __next__(self):
+        breakpoint()
+        batch = []
+        for _ in range(self.batch_size):
+            batch.append(torch.tensor(self.buffer[: self.sequence_length]))
+            self.buffer = self.buffer[self.sequence_length :]
+        return torch.stack(batch)
+
+# class SubsetFalconLoader(IterableDataset):
+#     max_pages: int = 968000015
+
+#     def __init__(self, batch_size, sequence_length, pages: typing.List[int]):
+#         self.batch_size = batch_size
+#         self.sequence_length = sequence_length
+#         self.num_rows_per_page = 100
+#         self.tokenizer = tokenizer
+#         self.base_url = "https://datasets-server.huggingface.co/rows"
+#         self.params = {
+#             "dataset": "tiiuae/falcon-refinedweb",
+#             "config": "default",
+#             "split": "train",
+#         }
+#         self.pages = pages
+#         self.buffer = []
+#         self.retry_limit = 10  # Number of retries
+#         self.retry_delay = 5  # Seconds to wait between retries
+
+#         for page in self.pages:
+#             self.fetch_data_for_page(page)
+
+#     def fetch_data_for_page(self, page):
+#         self.params["offset"] = page
+#         self.params["limit"] = self.num_rows_per_page
+#         attempt = 0
+#         while attempt < self.retry_limit:
+#             try:
+#                 response = requests.get(self.base_url, params=self.params)
+#                 response.raise_for_status()  # This will raise an HTTPError if the HTTP request returned an unsuccessful status code
+#                 for row in response.json()["rows"]:
+#                     content = row["row"]["content"]
+#                     self.buffer += self.tokenizer(content, truncation=True)["input_ids"]
+#                     self.buffer += [self.tokenizer.eos_token_id]
+#                 break  # If the request was successful, break out of the retry loop
+#             except requests.exceptions.RequestException as e:
+#                 attempt += 1
+#                 bt.logging.warning(
+#                     f"Failed to fetch data, retrying. Attempt {attempt}/{self.retry_limit}"
+#                 )
+#                 if attempt < self.retry_limit:
+#                     time.sleep(self.retry_delay)  # Wait before the next retry
+#                 else:
+#                     bt.logging.error(
+#                         "Maximum retry limit reached. Unable to fetch data."
+#                     )
+#                     raise
+
+#     def __iter__(self):
+#         breakpoint()
+#         while len(self.buffer) >= self.sequence_length * self.batch_size:
+#             batch = []
+#             for _ in range(self.batch_size):
+#                 batch.append(torch.tensor(self.buffer[: self.sequence_length]))
+#                 self.buffer = self.buffer[self.sequence_length :]
+#             yield torch.stack(batch)
+
+#     def __next__(self):
+#         breakpoint()
+#         batch = []
+#         for _ in range(self.batch_size):
+#             batch.append(torch.tensor(self.buffer[: self.sequence_length]))
+#             self.buffer = self.buffer[self.sequence_length :]
+#         return torch.stack(batch)
+
+loader = SubsetFalconLoader(
+    batch_size=10, sequence_length=1024, tokenizer = tokenizer, rows=[i for i in range(0,200)]
+)
+
+# loader = SubsetFalconLoader(
+#     batch_size=10, sequence_length=1024, pages=[1]
+# )
+
+for i, batch in enumerate(loader):
+    print(i)
+    print(batch)

--- a/template/data/dataset.py
+++ b/template/data/dataset.py
@@ -31,7 +31,7 @@ tokenizer.pad_token = tokenizer.eos_token
 class SubsetFalconLoader(IterableDataset):
     max_pages: int = 968000015
 
-    def __init__(self, batch_size, sequence_length, tokenizer, rows: typing.List[int]):
+    def __init__(self, batch_size, sequence_length, rows: typing.List[int], tokenizer = tokenizer):
         self.batch_size = batch_size
         self.sequence_length = sequence_length
         self.tokenizer = tokenizer
@@ -98,4 +98,4 @@ loader = SubsetFalconLoader(
 for i, batch in enumerate(loader):
     print(i)
     print(batch)
-breakpoint()
+# breakpoint()

--- a/template/protocol.py
+++ b/template/protocol.py
@@ -82,10 +82,13 @@ class Train( bt.Synapse ):
     # optimizer_name: str = "adam"
 
     # # Required batch size
-    batch_size: int = 1
+    batch_size: int = 2
+
+    # # Required gradient_accumilation_steps
+    gradient_accumilation_steps: int = 16
 
     # # Optional score
     loss: float = 0.0
     
-    # # Training Steps
-    # steps: int = 10
+    # Epoch
+    epoch: int | None

--- a/template/utils/config.py
+++ b/template/utils/config.py
@@ -143,7 +143,7 @@ def add_args(cls, parser):
         "--neuron.local_batch_size_train",
         type=int,
         help="The default batch size",
-        default=10,
+        default=2,
     )
 
     parser.add_argument(

--- a/template/utils/config.py
+++ b/template/utils/config.py
@@ -122,7 +122,7 @@ def add_args(cls, parser):
         "--neuron.model_name",
         type=str,
         help="The model to be trained",
-        default="kmfoda/gpt2-1b",
+        default="kmfoda/gpt2-677m",
     )
 
     parser.add_argument(
@@ -164,7 +164,7 @@ def add_args(cls, parser):
         "--neuron.run_id",
         type=str,
         help="The DHT run_id",
-        default="s25_run_v9",
+        default="s25_run_v10",
     )
 
     parser.add_argument(

--- a/template/utils/config.py
+++ b/template/utils/config.py
@@ -150,14 +150,14 @@ def add_args(cls, parser):
         "--neuron.global_batch_size_train",
         type=int,
         help="The hivemind global target_batch_size",
-        default=8000,
+        default=1600,
     )
 
     parser.add_argument(
         "--neuron.local_gradient_accumilation_steps_train",
         type=int,
         help="The default batch size",
-        default=1,
+        default=16,
     )
 
     parser.add_argument(
@@ -213,7 +213,7 @@ def add_args(cls, parser):
             "--neuron.local_gradient_accumilation_steps_test",
             type=int,
             help="The default batch size",
-            default=1,
+            default=16,
         )
 
         parser.add_argument(

--- a/template/utils/config.py
+++ b/template/utils/config.py
@@ -164,7 +164,7 @@ def add_args(cls, parser):
         "--neuron.run_id",
         type=str,
         help="The DHT run_id",
-        default="s25_run_v3",
+        default="s25_run_v5",
     )
 
     parser.add_argument(

--- a/template/utils/config.py
+++ b/template/utils/config.py
@@ -114,7 +114,7 @@ def add_args(cls, parser):
         nargs="+",
         help="The addresses for the DHT",
         default=[
-            "/ip4/69.30.85.70/tcp/22051/p2p/12D3KooWC1ipfGddeZunJe4s6bB2bhKCTCyb9FfhfR1XZwhFgBk1",
+            "/ip4/69.30.85.69/tcp/22162/p2p/12D3KooWGjNpqMSQaWudtrBseypWVRMccRiQAWzV1QoPzbki8fRs",
         ],
     )
 

--- a/template/utils/config.py
+++ b/template/utils/config.py
@@ -154,6 +154,13 @@ def add_args(cls, parser):
     )
 
     parser.add_argument(
+        "--neuron.local_gradient_accumilation_steps_train",
+        type=int,
+        help="The default batch size",
+        default=16,
+    )
+
+    parser.add_argument(
         "--neuron.run_id",
         type=str,
         help="The DHT run_id",
@@ -200,6 +207,13 @@ def add_args(cls, parser):
             type=int,
             help="The default batch size",
             default=4,
+        )
+
+        parser.add_argument(
+            "--neuron.local_gradient_accumilation_steps_test",
+            type=int,
+            help="The default batch size",
+            default=16,
         )
 
         parser.add_argument(

--- a/template/utils/config.py
+++ b/template/utils/config.py
@@ -199,7 +199,7 @@ def add_args(cls, parser):
             "--neuron.local_batch_size_test",
             type=int,
             help="The default batch size",
-            default=8,
+            default=4,
         )
 
         parser.add_argument(

--- a/template/utils/config.py
+++ b/template/utils/config.py
@@ -164,7 +164,7 @@ def add_args(cls, parser):
         "--neuron.run_id",
         type=str,
         help="The DHT run_id",
-        default="s25_run_v7",
+        default="s25_run_v8",
     )
 
     parser.add_argument(

--- a/template/utils/config.py
+++ b/template/utils/config.py
@@ -164,7 +164,7 @@ def add_args(cls, parser):
         "--neuron.run_id",
         type=str,
         help="The DHT run_id",
-        default="s25_run_v6",
+        default="s25_run_v7",
     )
 
     parser.add_argument(

--- a/template/utils/config.py
+++ b/template/utils/config.py
@@ -122,7 +122,7 @@ def add_args(cls, parser):
         "--neuron.model_name",
         type=str,
         help="The model to be trained",
-        default="kmfoda/gpt2",
+        default="kmfoda/gpt2-1b",
     )
 
     parser.add_argument(
@@ -164,7 +164,7 @@ def add_args(cls, parser):
         "--neuron.run_id",
         type=str,
         help="The DHT run_id",
-        default="s25_run_v8",
+        default="s25_run_v9",
     )
 
     parser.add_argument(

--- a/template/utils/config.py
+++ b/template/utils/config.py
@@ -123,14 +123,14 @@ def add_args(cls, parser):
         "--neuron.model_name",
         type=str,
         help="The model to be trained",
-        default="sshleifer/tiny-gpt2",
+        default="gpt2",
     )
 
     parser.add_argument(
         "--neuron.lr",
         type=float,
         help="The learning rate",
-        default=0.001,
+        default=0.0001),
     )
 
     parser.add_argument(
@@ -151,7 +151,7 @@ def add_args(cls, parser):
         "--neuron.global_batch_size_train",
         type=int,
         help="The hivemind global target_batch_size",
-        default=3200,
+        default=16000,
     )
 
     parser.add_argument(

--- a/template/utils/config.py
+++ b/template/utils/config.py
@@ -114,8 +114,7 @@ def add_args(cls, parser):
         nargs=3,
         help="The addresses for the DHT",
         default=[
-            "/ip4/161.97.156.125/tcp/8001/p2p/12D3KooWNrfkQ8DX2RHW4c98c8As11wMNA425WTNohijyJQdA84Y",
-            "/ip4/54.205.54.19/tcp/8008/p2p/12D3KooWMY4YGYZ6JkWaCNKUeKQHAuxeQcMeoNfKHbbRXVoBaMiZ",
+            "/ip4/69.30.85.70/tcp/22051/p2p/12D3KooWC1ipfGddeZunJe4s6bB2bhKCTCyb9FfhfR1XZwhFgBk1",
         ],
     )
 
@@ -130,7 +129,7 @@ def add_args(cls, parser):
         "--neuron.lr",
         type=float,
         help="The learning rate",
-        default=0.0001),
+        default=0.0001
     )
 
     parser.add_argument(
@@ -158,7 +157,7 @@ def add_args(cls, parser):
         "--neuron.run_id",
         type=str,
         help="The DHT run_id",
-        default="s25_run_v2",
+        default="s25_run_v3",
     )
 
     parser.add_argument(
@@ -172,7 +171,7 @@ def add_args(cls, parser):
         "--neuron.wandb_project",
         type=str,
         help="The wandb project to log to",
-        default="subnet25",
+        default="subnet25_test",
     )
 
     parser.add_argument(

--- a/template/utils/config.py
+++ b/template/utils/config.py
@@ -143,7 +143,7 @@ def add_args(cls, parser):
         "--neuron.local_batch_size_train",
         type=int,
         help="The default batch size",
-        default=20,
+        default=10,
     )
 
     parser.add_argument(
@@ -199,7 +199,7 @@ def add_args(cls, parser):
             "--neuron.local_batch_size_test",
             type=int,
             help="The default batch size",
-            default=20,
+            default=10,
         )
 
         parser.add_argument(

--- a/template/utils/config.py
+++ b/template/utils/config.py
@@ -114,7 +114,7 @@ def add_args(cls, parser):
         nargs="+",
         help="The addresses for the DHT",
         default=[
-            "/ip4/69.30.85.69/tcp/22162/p2p/12D3KooWGjNpqMSQaWudtrBseypWVRMccRiQAWzV1QoPzbki8fRs",
+            "/ip4/69.30.85.69/tcp/22162/p2p/12D3KooWGc1irEf5N4Mz4Mxt59TVLDrfMaQffi3ELjTkd6N5rwv6",
         ],
     )
 
@@ -129,7 +129,7 @@ def add_args(cls, parser):
         "--neuron.lr",
         type=float,
         help="The learning rate",
-        default=0.0001
+        default=0.00001
     )
 
     parser.add_argument(
@@ -143,7 +143,7 @@ def add_args(cls, parser):
         "--neuron.local_batch_size_train",
         type=int,
         help="The default batch size",
-        default=1,
+        default=4,
     )
 
     parser.add_argument(
@@ -157,7 +157,7 @@ def add_args(cls, parser):
         "--neuron.local_gradient_accumilation_steps_train",
         type=int,
         help="The default batch size",
-        default=16,
+        default=4,
     )
 
     parser.add_argument(
@@ -206,14 +206,14 @@ def add_args(cls, parser):
             "--neuron.local_batch_size_test",
             type=int,
             help="The default batch size",
-            default=1,
+            default=4,
         )
 
         parser.add_argument(
             "--neuron.local_gradient_accumilation_steps_test",
             type=int,
             help="The default batch size",
-            default=16,
+            default=4,
         )
 
         parser.add_argument(

--- a/template/utils/config.py
+++ b/template/utils/config.py
@@ -114,7 +114,8 @@ def add_args(cls, parser):
         nargs="+",
         help="The addresses for the DHT",
         default=[
-            "/ip4/69.30.85.69/tcp/22162/p2p/12D3KooWGc1irEf5N4Mz4Mxt59TVLDrfMaQffi3ELjTkd6N5rwv6",
+            "/ip4/161.97.156.125/tcp/8001/p2p/12D3KooWNrfkQ8DX2RHW4c98c8As11wMNA425WTNohijyJQdA84Y",
+            "/ip4/54.205.54.19/tcp/8008/p2p/12D3KooWMY4YGYZ6JkWaCNKUeKQHAuxeQcMeoNfKHbbRXVoBaMiZ"
         ],
     )
 
@@ -164,7 +165,7 @@ def add_args(cls, parser):
         "--neuron.run_id",
         type=str,
         help="The DHT run_id",
-        default="s25_run_v10",
+        default="s25_run_v2_1",
     )
 
     parser.add_argument(
@@ -178,7 +179,7 @@ def add_args(cls, parser):
         "--neuron.wandb_project",
         type=str,
         help="The wandb project to log to",
-        default="subnet25_test",
+        default="subnet25",
     )
 
     parser.add_argument(

--- a/template/utils/config.py
+++ b/template/utils/config.py
@@ -164,7 +164,7 @@ def add_args(cls, parser):
         "--neuron.run_id",
         type=str,
         help="The DHT run_id",
-        default="s25_run_v5",
+        default="s25_run_v6",
     )
 
     parser.add_argument(

--- a/template/utils/config.py
+++ b/template/utils/config.py
@@ -111,7 +111,7 @@ def add_args(cls, parser):
     parser.add_argument(
         "--neuron.initial_peers",
         type=str,
-        nargs=3,
+        nargs="+",
         help="The addresses for the DHT",
         default=[
             "/ip4/69.30.85.70/tcp/22051/p2p/12D3KooWC1ipfGddeZunJe4s6bB2bhKCTCyb9FfhfR1XZwhFgBk1",
@@ -136,7 +136,7 @@ def add_args(cls, parser):
         "--neuron.dataset_name",
         type=str,
         help="The datasets the model will be trained on",
-        default="wikitext",
+        default="tiiuae/falcon-refinedweb",
     )
 
     parser.add_argument(
@@ -220,7 +220,7 @@ def add_args(cls, parser):
             "--neuron.training_examples_per_miner",
             type=int,
             help="The number of rows to train on per miner",
-            default=200,
+            default=500,
         )
 
         parser.add_argument(

--- a/template/utils/config.py
+++ b/template/utils/config.py
@@ -150,7 +150,7 @@ def add_args(cls, parser):
         "--neuron.global_batch_size_train",
         type=int,
         help="The hivemind global target_batch_size",
-        default=16000,
+        default=8000,
     )
 
     parser.add_argument(

--- a/template/utils/config.py
+++ b/template/utils/config.py
@@ -91,7 +91,7 @@ def add_args(cls, parser):
         "--neuron.epoch_length",
         type=int,
         help="The default epoch length (how often we set weights, measured in 12 second blocks).",
-        default=100,
+        default=5,
     )
 
     parser.add_argument(
@@ -157,7 +157,7 @@ def add_args(cls, parser):
         "--neuron.local_gradient_accumilation_steps_train",
         type=int,
         help="The default batch size",
-        default=16,
+        default=1,
     )
 
     parser.add_argument(
@@ -213,7 +213,7 @@ def add_args(cls, parser):
             "--neuron.local_gradient_accumilation_steps_test",
             type=int,
             help="The default batch size",
-            default=16,
+            default=1,
         )
 
         parser.add_argument(

--- a/template/utils/config.py
+++ b/template/utils/config.py
@@ -143,7 +143,7 @@ def add_args(cls, parser):
         "--neuron.local_batch_size_train",
         type=int,
         help="The default batch size",
-        default=2,
+        default=1,
     )
 
     parser.add_argument(
@@ -206,7 +206,7 @@ def add_args(cls, parser):
             "--neuron.local_batch_size_test",
             type=int,
             help="The default batch size",
-            default=4,
+            default=1,
         )
 
         parser.add_argument(

--- a/template/utils/config.py
+++ b/template/utils/config.py
@@ -129,7 +129,7 @@ def add_args(cls, parser):
         "--neuron.lr",
         type=float,
         help="The learning rate",
-        default=0.00001
+        default=0.001
     )
 
     parser.add_argument(
@@ -150,14 +150,14 @@ def add_args(cls, parser):
         "--neuron.global_batch_size_train",
         type=int,
         help="The hivemind global target_batch_size",
-        default=1600,
+        default=3200,
     )
 
     parser.add_argument(
         "--neuron.local_gradient_accumilation_steps_train",
         type=int,
         help="The default batch size",
-        default=4,
+        default=1,
     )
 
     parser.add_argument(
@@ -213,7 +213,7 @@ def add_args(cls, parser):
             "--neuron.local_gradient_accumilation_steps_test",
             type=int,
             help="The default batch size",
-            default=4,
+            default=1,
         )
 
         parser.add_argument(

--- a/template/utils/config.py
+++ b/template/utils/config.py
@@ -122,7 +122,7 @@ def add_args(cls, parser):
         "--neuron.model_name",
         type=str,
         help="The model to be trained",
-        default="gpt2",
+        default="kmfoda/gpt2",
     )
 
     parser.add_argument(

--- a/template/utils/config.py
+++ b/template/utils/config.py
@@ -199,7 +199,7 @@ def add_args(cls, parser):
             "--neuron.local_batch_size_test",
             type=int,
             help="The default batch size",
-            default=10,
+            default=8,
         )
 
         parser.add_argument(

--- a/template/utils/misc.py
+++ b/template/utils/misc.py
@@ -142,10 +142,10 @@ class AsyncDendritePool:
         return await query_async()
     
 
-def load_wandb(config, wallet):
+def load_wandb(config, wallet, neuron_type, peer_id):
 
     #signature = wallet.hotkey.sign(config.neuron.run_id).hex() #Extra for verification if needed
-    run_name = f"{config.neuron.run_id}_{config.neuron.name}_{wallet.hotkey.ss58_address}" #+ signature 
+    run_name = f"{config.neuron.run_id}_{neuron_type}_{wallet.hotkey.ss58_address}_{peer_id}" #+ signature 
     wandb_run = wandb.init(
         id = run_name,
         name=run_name,

--- a/template/utils/misc.py
+++ b/template/utils/misc.py
@@ -145,7 +145,7 @@ class AsyncDendritePool:
 def load_wandb(config, wallet):
 
     #signature = wallet.hotkey.sign(config.neuron.run_id).hex() #Extra for verification if needed
-    run_name = config.neuron.run_id + "_" + wallet.hotkey.ss58_address#+ signature 
+    run_name = f"{config.neuron.run_id}_{config.neuron.name}_{wallet.hotkey.ss58_address}" #+ signature 
     wandb_run = wandb.init(
         id = run_name,
         name=run_name,

--- a/template/validator/forward.py
+++ b/template/validator/forward.py
@@ -43,6 +43,7 @@ async def forward(self):
     self.miner_uids = await get_random_uids(
         self, dendrite=self.dendrite, k=self.config.neuron.sample_size
     )
+    bt.logging.info(f"UIDs:  {self.miner_uids}")
     datapoints_per_group = self.config.neuron.training_examples_per_miner
     self.dataset_indices_list = self.dataset_common_state.get_dataset_indices(
             groups_count=len(self.miner_uids),
@@ -101,6 +102,8 @@ async def forward(self):
     self.current_epoch = self.opt.tracker.global_progress.epoch
 
     # Update global step
-    self.dataset_common_state.update_step()
+    step_update_status = self.dataset_common_state.update_step()
+    if step_update_status is None:
+        self.global_step += 1
 
     return responses

--- a/template/validator/forward.py
+++ b/template/validator/forward.py
@@ -39,18 +39,16 @@ async def forward(self):
         self (:obj:`bittensor.neuron.Neuron`): The neuron object which contains all the necessary state for the validator.
 
     """
-    breakpoint()
     self.miner_uids = await get_random_uids(
         self, dendrite=self.dendrite, k=self.config.neuron.sample_size
     )
-    breakpoint()
     datapoints_per_group = self.config.neuron.training_examples_per_miner
-    breakpoint()
+    import torch
+    self.miner_uids = torch.tensor([0])
     self.dataset_indices_list = self.dataset_common_state.get_dataset_indices(
             groups_count=len(self.miner_uids),
             items_per_group=datapoints_per_group,
     )
-    breakpoint()
     if not self.config.neuron.dont_wandb_log:
         self.wandb.log({"uids":self.miner_uids,
                     "dataset_indices":self.dataset_indices_list})

--- a/template/validator/forward.py
+++ b/template/validator/forward.py
@@ -63,7 +63,7 @@ async def forward(self):
             template.protocol.Train( 
                 dataset_indices = uid_dataset,
                 run_id = self.config.neuron.run_id,
-                batch_size = self.config.neuron.local_batch_size_train
+                batch_size = self.config.neuron.local_batch_size_train,
                 gradient_accumilation_steps = self.config.neuron.local_gradient_accumilation_steps_train
             )
         )
@@ -97,5 +97,8 @@ async def forward(self):
     
     # Update the scores based on the rewards.
     self.update_scores(rewards, self.miner_uids)
+
+    # Update the current_epoch
+    self.current_epoch = self.opt.tracker.global_progress.epoch
 
     return responses

--- a/template/validator/forward.py
+++ b/template/validator/forward.py
@@ -26,6 +26,7 @@ from template.utils.uids import get_random_uids
 
 import template
 import asyncio
+import torch
 
 
 async def forward(self):
@@ -43,7 +44,6 @@ async def forward(self):
         self, dendrite=self.dendrite, k=self.config.neuron.sample_size
     )
     datapoints_per_group = self.config.neuron.training_examples_per_miner
-    import torch
     self.miner_uids = torch.tensor([0])
     self.dataset_indices_list = self.dataset_common_state.get_dataset_indices(
             groups_count=len(self.miner_uids),
@@ -100,5 +100,8 @@ async def forward(self):
 
     # Update the current_epoch
     self.current_epoch = self.opt.tracker.global_progress.epoch
+
+    # Update global step
+    self.dataset_common_state.update_step()
 
     return responses

--- a/template/validator/forward.py
+++ b/template/validator/forward.py
@@ -63,7 +63,8 @@ async def forward(self):
             template.protocol.Train( 
                 dataset_indices = uid_dataset,
                 run_id = self.config.neuron.run_id,
-                batch_size = self.config.neuron.local_batch_size_train  #TODO let miners decide this? Based on their hardware. Then reconcile if needed?
+                batch_size = self.config.neuron.local_batch_size_train
+                gradient_accumilation_steps = self.config.neuron.local_gradient_accumilation_steps_train
             )
         )
 

--- a/template/validator/forward.py
+++ b/template/validator/forward.py
@@ -99,7 +99,7 @@ async def forward(self):
     self.update_scores(rewards, self.miner_uids)
 
     # Update the current_epoch
-    self.current_epoch = self.opt.tracker.global_progress.epoch
+    self.current_epoch = 1 # Dummy fix need to switch to self.tracker.global_progress.epoch
 
     # Update global step
     step_update_status = self.dataset_common_state.update_step()

--- a/template/validator/forward.py
+++ b/template/validator/forward.py
@@ -39,17 +39,18 @@ async def forward(self):
         self (:obj:`bittensor.neuron.Neuron`): The neuron object which contains all the necessary state for the validator.
 
     """
-    
+    breakpoint()
     self.miner_uids = await get_random_uids(
         self, dendrite=self.dendrite, k=self.config.neuron.sample_size
     )
+    breakpoint()
     datapoints_per_group = self.config.neuron.training_examples_per_miner
-    
+    breakpoint()
     self.dataset_indices_list = self.dataset_common_state.get_dataset_indices(
             groups_count=len(self.miner_uids),
             items_per_group=datapoints_per_group,
     )
-
+    breakpoint()
     if not self.config.neuron.dont_wandb_log:
         self.wandb.log({"uids":self.miner_uids,
                     "dataset_indices":self.dataset_indices_list})

--- a/template/validator/forward.py
+++ b/template/validator/forward.py
@@ -44,7 +44,6 @@ async def forward(self):
         self, dendrite=self.dendrite, k=self.config.neuron.sample_size
     )
     datapoints_per_group = self.config.neuron.training_examples_per_miner
-    self.miner_uids = torch.tensor([0])
     self.dataset_indices_list = self.dataset_common_state.get_dataset_indices(
             groups_count=len(self.miner_uids),
             items_per_group=datapoints_per_group,

--- a/template/validator/reward.py
+++ b/template/validator/reward.py
@@ -22,28 +22,28 @@ from typing import List
 
 import bittensor as bt
 import torch
+from template.data.dataset import SubsetFalconLoader
 
 def get_loss(self, dataset_indices):
 
     # Create Dataloader
     dataloader = SubsetFalconLoader(
-        batch_size=self.config.neuron.local_batch_size_test, sequence_length=1024, rows=synapse.dataset_indices
+        batch_size=self.config.neuron.local_batch_size_test, sequence_length=1024, rows=dataset_indices
     )
 
     # Loop to the last batch to test the current state's loss on the last batch of test data
     for step, batch in enumerate(dataloader):
         continue
 
-    input_ids = batch["input_ids"].to(self.device)
-    attention_mask = batch["attention_mask"].to(self.device)
-    labels = input_ids.clone()
+
+    inputs = batch.to(self.device)
+    input_ids = inputs
+    labels = inputs
 
     # self.opt.zero_grad()
 
     # Forward pass
-    outputs = self.model(
-        input_ids=input_ids, attention_mask=attention_mask, labels=labels
-    )
+    outputs = self.model(input_ids=input_ids, labels=labels)
 
     # Backward pass
     loss = outputs.loss

--- a/template/validator/reward.py
+++ b/template/validator/reward.py
@@ -73,7 +73,7 @@ def get_loss(self, dataset_indices, batch_size, gradient_accumilation_steps):
         bt.logging.info(f"Step {step} Loss: {outputs.loss.detach().item()}")
     
         if not self.config.neuron.dont_wandb_log:
-            self.wandb.log({"loss": outputs.loss.detach().item(), "opt_local_epoch": self.opt.local_epoch})
+            self.wandb.log({"loss": outputs.loss.detach().item()})
 
     average_loss = total_loss / step
 

--- a/template/validator/reward.py
+++ b/template/validator/reward.py
@@ -62,9 +62,9 @@ def get_loss(self, dataset_indices, batch_size, gradient_accumilation_steps):
 
     return outputs.loss.detach().item()
 
-def get_local_score(self, synapse, current_epoch):
+def get_local_score(self, synapse):
 
-    if self.state_averager.opt.tracker.global_progress.epoch != current_epoch:
+    if self.opt.tracker.global_progress.epoch != self.current_epoch:
         score = 1
     else:
         loss = get_loss(self, synapse.dataset_indices, synapse.batch_size, synapse.gradient_accumilation_steps)
@@ -95,7 +95,7 @@ def get_rewards(
     retries = 0
     while load_state_from_peers_status is False:
         try:
-            load_state_from_peers_status = self.state_averager.load_state_from_peers()
+            load_state_from_peers_status = self.opt.state_averager.load_state_from_peers()
         except Exception as e:
             bt.logging.error(f"Attempt {retries + 1} to write to the load state from peers failed: {e}")
             retries += 1
@@ -151,7 +151,7 @@ def get_rewards(
     scores = torch.FloatTensor([scores[uid_index] * get_local_score(self, responses[0][uid_index]) 
                                 if uid_index in test_uids_sample_index else scores[uid_index] 
                                 for uid_index,_ in enumerate(uids)]).to(self.device)
-    
+
     bt.logging.info(f"Adjusted Global Scores: {scores}")
     
     return scores

--- a/template/validator/reward.py
+++ b/template/validator/reward.py
@@ -152,7 +152,7 @@ def get_rewards(
     self.previous_loss = loss
     
     # Write loss to dht
-    store_loss = self.dataset_common_state.store_dht("loss", loss, get_dht_time() + self.default_expiration_time )
+    store_loss = self.dataset_common_state.set_dht("loss", loss, get_dht_time() + self.default_expiration_time )
     if not store_loss:
         bt.logging.error(f"Failed to store key: loss")
 

--- a/template/validator/reward.py
+++ b/template/validator/reward.py
@@ -47,7 +47,7 @@ def get_loss(self, dataset_indices):
 
 def get_local_score(self, synapse):
 
-    loss = get_loss(self, synapse.dataset_indices[-synapse.batch_size:])
+    loss = get_loss(self, synapse.dataset_indices[-self.config.neuron.local_batch_size_test:])
     # The miner's local score is the variance between the loss it returns and the 
     # loss the validator calculates for the last batch of data sent to that miner
     score = 1-(abs(loss-synapse.loss)/loss)

--- a/template/validator/reward.py
+++ b/template/validator/reward.py
@@ -100,15 +100,15 @@ def get_rewards(
     - torch.FloatTensor: A tensor of rewards for the given query and responses.
     """
 
-    # load_state_from_peers_status = False
-    # retries = 0
-    # while load_state_from_peers_status is False:
-    #     try:
-    #         load_state_from_peers_status = self.opt.state_averager.load_state_from_peers()
-    #     except Exception as e:
-    #         bt.logging.error(f"Attempt {retries + 1} to write to the load state from peers failed: {e}")
-    #         retries += 1
-    #         bt.logging.error(f"Retrying ...")
+    load_state_from_peers_status = False
+    retries = 0
+    while load_state_from_peers_status is False:
+        try:
+            load_state_from_peers_status = self.opt.state_averager.load_state_from_peers()
+        except Exception as e:
+            bt.logging.error(f"Attempt {retries + 1} to write to the load state from peers failed: {e}")
+            retries += 1
+            bt.logging.error(f"Retrying ...")
 
     self.global_step = self.dataset_common_state.get_dht("step")
     bt.logging.info(f"Global Step:   {self.global_step}")

--- a/template/validator/reward.py
+++ b/template/validator/reward.py
@@ -45,7 +45,7 @@ def get_loss(self, dataset_indices, batch_size, gradient_accumilation_steps):
         outputs = self.model(input_ids=inputs, labels=inputs)
         
         # Zero gradients
-        self.opt.zero_grad()
+        # self.opt.zero_grad()
 
         # Normalize loss to account for batch accumulation
         # loss = outputs.loss / accumulation_steps 
@@ -58,7 +58,7 @@ def get_loss(self, dataset_indices, batch_size, gradient_accumilation_steps):
         loss.backward()
 
         # Adjust gradient
-        self.opt.step()
+        # self.opt.step()
 
         # if (step + 1) % accumulation_steps == 0:
         #     n_acc_steps += 1

--- a/template/validator/validator_core.py
+++ b/template/validator/validator_core.py
@@ -1,17 +1,10 @@
-import json
 import random
 import time
-from time import sleep
 
 import bittensor as bt
 import torch
 from hivemind.utils.timed_storage import get_dht_time
-from transformers import (
-    AdamW,
-    AutoModelForCausalLM,
-    AutoTokenizer,
-    get_linear_schedule_with_warmup,
-)
+
 from bitarray import bitarray
 
 class DatasetState:
@@ -22,76 +15,70 @@ class DatasetState:
     If the indices run out then a new epoch is calculated and the number of available indices is reset to full.
     The following
     """
-    def __init__(self, dht_state, dataset_indices, run_id, default_expiration_time=600):
+    def __init__(self, dht, dataset_indices, run_id, default_expiration_time=600):
         assert run_id, "run_id isn't specified when run_id can't be empty/zero/null"
-        self.dht_state = dht_state
+        self.dht = dht
         self.default_expiration_time = default_expiration_time
         self.run_id = run_id
         self.dataset_indices_original = dataset_indices
         self.dataset_indices_train = dataset_indices
         self.loss = None
+        self.epoch = 0
         self.set_dht("dataset_indices_train", self.dataset_indices_train)
         self.set_dht("loss", self.loss)
-
+        self.set_dht("epoch", self.epoch)
+        
         if self.dataset_indices_train is None:
             self.dataset_indices_train = self.get_dht("dataset_indices_train")
         if self.loss is None:
             self.loss = self.get_dht("loss")
-
-    def _serialize_to_string(self, data_str):
-        return json.dumps(data_str)
-
-    def _deserialize_from_string(self, data_str):
-        return json.loads(data_str)
-
+        if self.epoch is None:
+            self.epoch = self.get_dht("epoch")
+   
     def get_dht(self, name):
-        if isinstance(self.dht_state, dict):
-            return self.dht_state.get(name)
+        try:
+            value, expiration = self.dht.get(name, latest=True)
+            if value is not None:
+                return value
+        except Exception as e:
+            print(f"Error accessing DHT: {e}")
+        return None
 
     def set_dht(self, name, value):
-        if isinstance(self.dht_state, dict):
-            self.dht_state[name] = value
-
-    def get_dataset_indices(self, groups_count, items_per_group):
-        indices = self.get_dht("dataset_indices_train")
-
-        no_value_flag = False
-
         try:
-            no_value_flag = len(indices) < (groups_count * items_per_group)
-        except:
-            no_value_flag = True
-
-        if no_value_flag:
-            print("Ran out of dataset indices. Reloading")
-            self.set_dht("dataset_indices_train", self.dataset_indices_original)
-            try:
-                self.epoch += 1
-            except AttributeError:
-                self.epoch = 1
+            expiration_time = get_dht_time() + self.default_expiration_time
+            store_ok = self.dht.store(name, value, expiration_time=expiration_time)
+            if not store_ok:
+                print(f"Failed to store key: {name}")
+        except Exception as e:
+            print(f"Error storing to DHT: {e}")
+    
+    def get_dataset_indices(self, groups_count, items_per_group):
+        
+        if self.dataset_indices_train.count(0) < groups_count * items_per_group:
+            print("Ran out of dataset indices. Resetting")
+            self.dataset_indices_train.setall(0)
+            self.epoch += 1
+            self.set_dht("epoch", self.epoch)
             return self.get_dataset_indices(groups_count, items_per_group)
         
         selected_groups = []
         for _ in range(groups_count):
-            search_start = random.choice(range(len(indices) - items_per_group + 1))
-            start = indices.index(bitarray('0'*items_per_group), search_start)
+            search_start = random.choice(range(len(self.dataset_indices_train) - items_per_group + 1))
+            start = self.dataset_indices_train.index(bitarray('0'*items_per_group), search_start)
             group = [i for i in range(start,start + items_per_group)]
             selected_groups.append(group)
 
-            indices[group] = True
+            self.dataset_indices_train[group] = True
 
-        bt.logging.info("Removing selected indices from the DHT")
-        self.set_dht("dataset_indices_train", indices)
         return selected_groups
 
     def get_dataset_indices_test(self, batch_size):
-        dataset_indices_train = self.get_dht("dataset_indices_train")
-        start = random.choice(range(len(dataset_indices_train) - batch_size + 1))
+        start = random.choice(range(len(self.dataset_indices_train) - batch_size + 1))
         dataset_indices_test = [i for i in range(start, start + batch_size)]
         self.set_dht("dataset_indices_test", dataset_indices_test)
-        # dataset_indices_train = dataset_indices_train[:start] + dataset_indices_train[start + batch_size:]
-        dataset_indices_train[start:start + batch_size] = True
-        self.set_dht("dataset_indices_train", dataset_indices_train)
+        self.dataset_indices_train[start:start + batch_size] = True
+
         return dataset_indices_test
 
     # def update_step(cls):
@@ -110,3 +97,28 @@ def upload_checkpoint(commit_message, state_averager, model, repo_path, repo_url
         commit_message=commit_message,
     )
     bt.logging.info("Finished uploading to Model Hub")
+
+if __name__ == "__main__":
+    import hivemind
+    # Initialize the dummy data and the DatasetState instance
+    dataset_length = 96015  # Reduced size for testing
+    dataset_indices = bitarray('0' * dataset_length)  # Initialize all indices to 0 (unused)
+    #dataset_dict = {}  # Dummy DHT, aka dht_state
+    dht = hivemind.DHT(start=True)
+    run_id = "dummy_run_id"
+   
+    dataset_state = DatasetState(dht, dataset_indices, run_id)
+    
+    # Test get_dataset_indices
+    selected_groups = dataset_state.get_dataset_indices(2, 500)
+    print("Selected groups for training:", selected_groups)
+    print(dataset_state.dataset_indices_train.count(0))
+    selected_groups = dataset_state.get_dataset_indices(2, 500)
+    print("Selected groups for training:", selected_groups)
+    print(dataset_state.dataset_indices_train.count(0))
+
+    # Test get_dataset_indices_test with DHT
+    test_indices = dataset_state.get_dataset_indices_test(20)
+    print(test_indices)
+    print(dht.get("dataset_indices_test"))
+    dht.shutdown()

--- a/template/validator/validator_core.py
+++ b/template/validator/validator_core.py
@@ -1,6 +1,7 @@
 import random
 from bitarray import bitarray
 from hivemind.utils.timed_storage import get_dht_time
+import bittensor as bt
 
 class DatasetState:
     """
@@ -35,7 +36,7 @@ class DatasetState:
             if value is not None:
                 return value.value
         except Exception as e:
-            print(f"Error accessing DHT: {e}")
+            bt.logging.error(f"Error accessing DHT: {e}")
         return None
 
     def set_dht(self, name, value):
@@ -43,9 +44,9 @@ class DatasetState:
             expiration_time = get_dht_time() + self.default_expiration_time
             store_ok = self.dht.store(name, value, expiration_time=expiration_time)
             if not store_ok:
-                print(f"Failed to store key: {name}")
+                bt.logging.error(f"Failed to store key: {name}")
         except Exception as e:
-            print(f"Error storing to DHT: {e}")
+            bt.logging.error(f"Error storing to DHT: {e}")
     
     def get_dataset_indices(self, groups_count, items_per_group):
         

--- a/template/validator/validator_core.py
+++ b/template/validator/validator_core.py
@@ -82,6 +82,7 @@ class DatasetState:
         return selected_groups
 
     def get_dataset_indices_test(self, batch_size):
+        breakpoint()
         dataset_indices_train = self.get_dht("dataset_indices_train")
         start = random.choice(range(len(dataset_indices_train) - batch_size + 1))
         dataset_indices_test = dataset_indices_train[start:start + batch_size]

--- a/template/validator/validator_core.py
+++ b/template/validator/validator_core.py
@@ -78,4 +78,7 @@ class DatasetState:
 
     def update_step(self):
         self.step = self.get_dht("step")
-        self.set_dht("step", self.step + 1)
+        if self.step is not None:
+            self.set_dht("step", self.step + 1)
+        else:
+            return None

--- a/template/validator/validator_core.py
+++ b/template/validator/validator_core.py
@@ -1,11 +1,6 @@
 import random
-import time
-
-import bittensor as bt
-import torch
-from hivemind.utils.timed_storage import get_dht_time
-
 from bitarray import bitarray
+from hivemind.utils.timed_storage import get_dht_time
 
 class DatasetState:
     """

--- a/tests/datasetstate_test.py
+++ b/tests/datasetstate_test.py
@@ -1,0 +1,26 @@
+import hivemind
+from bitarray import bitarray
+from template.validator.validator_core import DatasetState
+
+# Initialize the dummy data and the DatasetState instance
+dataset_length = 96015  # Reduced size for testing
+dataset_indices = bitarray('0' * dataset_length)  # Initialize all indices to 0 (unused)
+#dataset_dict = {}  # Dummy DHT, aka dht_state
+dht = hivemind.DHT(start=True)
+run_id = "dummy_run_id"
+
+dataset_state = DatasetState(dht, dataset_indices, run_id)
+
+# Test get_dataset_indices
+selected_groups = dataset_state.get_dataset_indices(2, 500)
+print("Selected groups for training:", selected_groups)
+print(dataset_state.dataset_indices_train.count(0))
+selected_groups = dataset_state.get_dataset_indices(2, 500)
+print("Selected groups for training:", selected_groups)
+print(dataset_state.dataset_indices_train.count(0))
+
+# Test get_dataset_indices_test with DHT
+test_indices = dataset_state.get_dataset_indices_test(20)
+print(test_indices)
+print(dht.get("dataset_indices_test"))
+dht.shutdown()

--- a/tests/miner_test.py
+++ b/tests/miner_test.py
@@ -1,28 +1,32 @@
-import random
+import os
+import time
 from functools import partial
 from ipaddress import ip_address
 
 import hivemind
 import requests
 import torch
+import torch.nn.functional as F
 from datasets import load_dataset
+from torch import nn
 from torch.utils.data import DataLoader
-from torch_optimizer import Lamb
 from tqdm import tqdm
-from transformers import (AutoModelForCausalLM, AutoTokenizer,
-                          default_data_collator)
+from transformers import AutoModelForCausalLM, AutoTokenizer, default_data_collator
 
 
 # Define encoding function
 def encode(examples):
-    return tokenizer(examples['text'], truncation=True, max_length=512, padding='max_length')
+    return tokenizer(
+        examples["text"], truncation=True, max_length=512, padding="max_length"
+    )
 
 
 # Create dataset and model, same as in the basic tutorial
-model = AutoModelForCausalLM.from_pretrained("sshleifer/tiny-gpt2")
-device = "cpu"
-
-opt = torch.optim.AdamW(model.parameters(), lr=0.001)
+model = AutoModelForCausalLM.from_pretrained("gpt2")
+device = "cuda"
+port = 22051
+model = model.to(device)
+opt = torch.optim.AdamW(model.parameters(), lr=0.0001)
 
 request = requests.get("https://api.ipify.org")
 request.raise_for_status()
@@ -30,84 +34,134 @@ request.raise_for_status()
 address = request.text
 print(f"Received public IP address of this machine: {address}")
 version = ip_address(address).version
-announce_maddrs = [f"/ip{version}/{address}/tcp/{8009}"]
-print(announce_maddrs)
+announce_maddrs = [f"/ip{version}/{address}/tcp/{port}"]
+
+version = "4"
+# address = "34.229.118.117"
+announce_maddrs = [f"/ip{version}/{address}/tcp/{port}"]
+
 # Create DHT: a decentralized key-value storage shared between peers
 dht = hivemind.DHT(
-    host_maddrs=[f"/ip4/0.0.0.0/tcp/{8009}"],
-    announce_maddrs = announce_maddrs,
-    start=True
+    host_maddrs=[f"/ip4/0.0.0.0/tcp/{port}"],
+    # initial_peers=["/ip4/161.97.156.125/tcp/41669/p2p/12D3KooWJWz47mnxvii7ErigQErfBeAhrWBhUTMUVruuEcKxNpMT","/ip4/69.30.85.69/tcp/22085/p2p/12D3KooWDzGzZYn1jFurAZCfpEjjKWXQ1mpSoGRTKofK4n4GidFz","/ip4/69.30.85.69/tcp/22085/p2p/12D3KooWQVbv3krYkkuU8NDdWYGC4cEtXtgHd5df3rW22GnZcSpM"],
+    announce_maddrs=announce_maddrs,
+    start=True,
 )
-print('\n'.join(str(addr) for addr in dht.get_visible_maddrs()))
+from hivemind import utils
 
+utils.log_visible_maddrs(dht.get_visible_maddrs(), only_p2p=True)
 # Set up a decentralized optimizer that will average with peers in background
 opt = hivemind.Optimizer(
-    dht=dht,                  # use a DHT that is connected with other peers
-    run_id='my_cifar_run',    # unique identifier of this collaborative run
-    batch_size_per_step=20,   # each call to opt.step adds this many samples towards the next epoch
-    target_batch_size=3000,    # after peers collectively process this many samples, average weights and begin the next epoch
-    optimizer=opt,            # wrap the SGD optimizer defined above
-    scheduler=partial(torch.optim.lr_scheduler.LambdaLR, lr_lambda=lambda t: 1.0 / max(1, t)),
-    use_local_updates=True,   # perform optimizer steps with local gradients, average parameters in background
-    matchmaking_time=15.0,     # when averaging parameters, gather peers in background for up to this many seconds
-    averaging_timeout=60.0,   # give up on averaging if not successful in this many seconds
-    verbose=True,              # print logs incessently
+    dht=dht,  # use a DHT that is connected with other peers
+    run_id="use_local",  # unique identifier of this collaborative run
+    batch_size_per_step=10,  # each call to opt.step adds this many samples towards the next epoch
+    target_batch_size=16000,  # after peers collectively process this many samples, average weights and begin the next epoch
+    optimizer=opt,  # wrap the SGD optimizer defined above
+    scheduler=partial(
+        torch.optim.lr_scheduler.LambdaLR, lr_lambda=lambda t: 1.0 / max(1, t)
+    ),
+    use_local_updates=False,  # perform optimizer steps with local gradients, average parameters in background
+    matchmaking_time=15.0,  # when averaging parameters, gather peers in background for up to this many seconds
+    averaging_timeout=600.0,  # give up on averaging if not successful in this many seconds
+    grad_compression=hivemind.Float16Compression(),
+    state_averaging_compression=hivemind.Float16Compression(),
+    verbose=True,  # print logs incessently
 )
 
-tokenizer = AutoTokenizer.from_pretrained("sshleifer/tiny-gpt2")
+tokenizer = AutoTokenizer.from_pretrained("gpt2")
 # Add the EOS token as PAD token to ensure our dataloader doesn't throw an error for sequences of unequal length
 tokenizer.pad_token = tokenizer.eos_token
 
 # Load dataset
-dataset = load_dataset("wikitext", 'wikitext-2-v1', split='train')
+dataset = load_dataset("wikitext", "wikitext-2-v1", split="train")
 encoded_dataset = dataset.map(encode, batched=True)
 
-chunk_size = 300
-num_iterations = len(dataset) // chunk_size
+# chunk_size = 200
+# num_iterations = len(dataset) // chunk_size
 
 opt.load_state_from_peers()
 
-#Get the total number of samples in the dataset
-num_samples = len(encoded_dataset)
+# for i in range(num_iterations):
+# print("Iteration:", i, "with new dataset indices")
+# # Select dataset indices for the current chunk
+# start_index = i * chunk_size
+# end_index = (i + 1) * chunk_size
+# dataset_indices = [j for j in range(start_index, end_index)]
 
-for i in range(num_iterations):
-    print("Iteration:", i, "with new dataset indices")
-    # Select random dataset indices for the current chunk
-    dataset_indices = random.sample(range(num_samples), chunk_size)
+# Create a PyTorch DataLoader
+# dataloader = DataLoader(encoded_dataset.select(dataset_indices), batch_size=10, collate_fn=default_data_collator)
+dataloader = DataLoader(
+    encoded_dataset, batch_size=10, collate_fn=default_data_collator
+)
 
-     # Create a PyTorch DataLoader
-    dataloader = DataLoader(encoded_dataset.select(dataset_indices), batch_size=10, collate_fn=default_data_collator)
+pb_bar = tqdm(
+    enumerate(dataloader), total=len(dataloader), dynamic_ncols=True, leave=False
+)
 
-    pb_bar = tqdm(enumerate(dataloader), total=len(dataloader), dynamic_ncols=True, leave=False)
+total_loss = 0
 
-    total_loss = 0 
+# Train data for one epoch
+for step, batch in pb_bar:
+    input_ids = batch["input_ids"].to(device)
+    attention_mask = batch["attention_mask"].to(device)
+    labels = input_ids.clone()
 
-    # Train data for one epoch
-    for step, batch in pb_bar:
-        input_ids = batch['input_ids'].to(device)
-        attention_mask = batch['attention_mask'].to(device)
-        labels = input_ids.clone()
-        
-        opt.zero_grad()
+    opt.zero_grad()
 
-        # Forward pass
-        outputs = model(
-            input_ids = input_ids, 
-            attention_mask = attention_mask,
-            labels = labels
-        )     
-        # Backward pass    
-        loss = outputs.loss
-        total_loss += loss.item()
-        
-        loss.backward()
-        # Adjust gradient
-        opt.step()
-        
-        #print(f"Step {step} Loss: {loss}")
-        pb_bar.set_description("Train loop: loss {:.4f} ".format(loss.item()))
+    # Forward pass
+    outputs = model(input_ids=input_ids, attention_mask=attention_mask, labels=labels)
+    # Backward pass
+    loss = outputs.loss
+    total_loss += loss.item()
 
-        #average_loss = total_loss / len(dataloader)
-        current_loss = loss / (step + 1)
-        print(f"Current Loss: {current_loss}")
-        #print(f"Final Average Loss: {average_loss}")
+    loss.backward()
+    # Adjust gradient
+    opt.step()
+    # breakpoint()
+    # control.should_log = True
+    # if not self.params_are_finite():
+    #     self.restore_from_backup(self.latest_backup)
+
+    # local_progress = self.optimizer.local_progress
+
+    # if state.log_history:
+    #     self.loss += state.log_history[-1]["loss"]
+    #     self.steps += 1
+
+    #     if self.optimizer.local_epoch != self.last_reported_collaboration_step:
+    #         self.last_reported_collaboration_step = self.optimizer.local_epoch
+    #         self.total_samples_processed += self.samples
+    #         samples_per_second = local_progress.samples_per_second
+    #         statistics = utils.LocalMetrics(
+    #             step=self.optimizer.local_epoch,
+    #             samples_per_second=samples_per_second,
+    #             samples_accumulated=self.samples,
+    #             loss=self.loss,
+    #             mini_steps=self.steps,
+    #         )
+    #         logger.info(f"Step #{self.optimizer.local_epoch}")
+    #         logger.info(f"Your current contribution: {self.total_samples_processed} samples")
+    #         logger.info(f"Performance: {samples_per_second:.3f} samples/sec")
+    #         if self.steps:
+    #             logger.info(f"Local loss: {self.loss / self.steps:.5f}")
+    #         if self.optimizer.local_epoch % self.backup_every_steps == 0:
+    #             self.latest_backup = self.backup_state()
+
+    #         self.loss = 0
+    #         self.steps = 0
+    #         if self.optimizer.is_synchronized_with_peers():
+    #             self.dht.store(
+    #                 key=self.optimizer.run_id + "_metrics",
+    #                 subkey=self.local_public_key,
+    #                 value=statistics.dict(),
+    #                 expiration_time=get_dht_time() + self.statistics_expiration,
+    #                 return_future=True,
+    #             )
+
+    # self.samples = local_progress.samples_accumulated
+
+    # print(f"Step {step} Loss: {loss}")
+    pb_bar.set_description("Train loop: loss {:.4f} ".format(loss.item()))
+
+average_loss = total_loss / len(dataloader)
+print(f"Final Average Loss: {average_loss}")

--- a/tests/miner_test.py
+++ b/tests/miner_test.py
@@ -117,7 +117,7 @@ for step, batch in pb_bar:
     loss.backward()
     # Adjust gradient
     opt.step()
-    # breakpoint()
+
     # control.should_log = True
     # if not self.params_are_finite():
     #     self.restore_from_backup(self.latest_backup)

--- a/tests/model_test.py
+++ b/tests/model_test.py
@@ -1,0 +1,51 @@
+import os
+import time
+from functools import partial
+from ipaddress import ip_address
+
+import hivemind
+import requests
+import torch
+import torch.nn.functional as F
+from datasets import load_dataset
+from torch import nn
+from torch.utils.data import DataLoader
+from tqdm import tqdm
+from transformers import AutoModelForCausalLM, AutoTokenizer, default_data_collator
+
+# Define encoding function
+def encode(examples):
+    return tokenizer(
+        examples["text"], truncation=True, max_length=512, padding="max_length"
+    )
+    
+# Create dataset and model, same as in the basic tutorial
+model = AutoModelForCausalLM.from_pretrained("gpt2", torch_dtype=torch.float16)
+device = "cuda"
+# model = model.to(dtype=torch.float16, device=device)
+model = model.to(device=device)
+opt = torch.optim.AdamW(model.parameters(), lr=0.0001)
+
+tokenizer = AutoTokenizer.from_pretrained("gpt2")
+# Add the EOS token as PAD token to ensure our dataloader doesn't throw an error for sequences of unequal length
+tokenizer.pad_token = tokenizer.eos_token
+
+# Load dataset
+dataset = load_dataset("wikitext", "wikitext-2-v1", split="train")
+encoded_dataset = dataset.map(encode, batched=True)
+
+dataloader = DataLoader(
+    encoded_dataset, batch_size=20, collate_fn=default_data_collator
+)
+
+# pb_bar = tqdm(
+#     enumerate(dataloader), total=len(dataloader), dynamic_ncols=True, leave=False
+# )
+
+# Train data for one epoch
+for step, batch in enumerate(dataloader):
+    input_ids = batch["input_ids"].to(device)
+    outputs = model(input_ids=input_ids, labels=input_ids)
+    loss = outputs.loss
+    loss.backward()
+    print(loss)


### PR DESCRIPTION
Todos:
- [x] Add gradient compression on miner and validator sides to reduce GPT2 `gradient_averaging` times
- [x] Add state compression on miner and validator sides to reduce GPT2 `load_state_from_paramater_peers`
- [x] Add a dataset.py file that streams and filters the `tiiuae/falcon-refinedweb` dataset
- [x] Convert the list of dataset indices we've trained on to a bitarray to be able to store a much larger list size
- [x] Add gradient checkpointing to remove OOM errors
- [x] Switch the DHT on the validator side to have client_mode=True
- [x] Replace the validator state_averager with a optimiser
- [x] Only perform local loss checks on miners when the global_epoch hasn't changed and therefore when the state hasn't been updated yet
- [x] Store`dataset_indices_test` in the DHT so that all validators can reference the same sub-dataset for testing and there have much more similar weights thereby improving vtrust issues.
- [ ] Update configs to main net before merge

Decommissioned to next release:
- [ ] Store `dataset_indices_train` in the DHT so that all validators can be aligned on which dataset_indices have been used for training yet vs not. Thereby enabling true Data Parallelism.