### PR TITLE
Only allow the master UID to call all reduce

### DIFF
--- a/distributed_training/__init__.py
+++ b/distributed_training/__init__.py
@@ -17,7 +17,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 # version nomenclature = __training_type__.__model__.__other_changes__
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 __run__ = "1"
 version_split = __version__.split(".")
 __spec_version__ = (

--- a/distributed_training/base/validator.py
+++ b/distributed_training/base/validator.py
@@ -19,6 +19,7 @@
 import _thread
 import asyncio
 import copy
+import os
 import threading
 from traceback import print_exception
 from typing import List
@@ -336,10 +337,12 @@ class BaseValidatorNeuron(BaseNeuron):
 
     def load_state(self):
         """Loads the state of the validator from a file."""
-        bt.logging.info("Loading validator state.")
-
-        # Load the state of the validator from file.
-        state = torch.load(self.config.neuron.full_path + "/state.pt")
-        self.step = state["step"]
-        self.scores = state["scores"]
-        self.hotkeys = state["hotkeys"]
+        if os.path.isfile(self.config.neuron.full_path + "/state.pt"):
+            bt.logging.info("Pre-Save validator state found. Loading validator state.")
+            # Load the state of the validator from file.
+            state = torch.load(self.config.neuron.full_path + "/state.pt")
+            self.step = state["step"]
+            self.scores = state["scores"]
+            self.hotkeys = state["hotkeys"]
+        else:
+            bt.logging.info("Pre-Save validator state not found.")

--- a/distributed_training/utils/config.py
+++ b/distributed_training/utils/config.py
@@ -130,7 +130,7 @@ def add_args(cls, parser):
         "--neuron.local_batch_size_train",
         type=int,
         help="The default batch size",
-        default=8,
+        default=6,
     )
 
     parser.add_argument(

--- a/distributed_training/utils/config.py
+++ b/distributed_training/utils/config.py
@@ -130,21 +130,14 @@ def add_args(cls, parser):
         "--neuron.local_batch_size_train",
         type=int,
         help="The default batch size",
-        default=1,
+        default=8,
     )
 
     parser.add_argument(
         "--neuron.global_batch_size_train",
         type=int,
         help="The hivemind global target_batch_size",
-        default=32000,
-    )
-
-    parser.add_argument(
-        "--neuron.local_gradient_accumilation_steps_train",
-        type=int,
-        help="The default batch size",
-        default=4,
+        default=70400,
     )
 
     parser.add_argument(
@@ -186,14 +179,7 @@ def add_args(cls, parser):
             "--neuron.local_batch_size_test",
             type=int,
             help="The default batch size",
-            default=1,
-        )
-
-        parser.add_argument(
-            "--neuron.local_gradient_accumilation_steps_test",
-            type=int,
-            help="The default batch size",
-            default=4,
+            default=8,
         )
 
         parser.add_argument(
@@ -214,7 +200,7 @@ def add_args(cls, parser):
             "--neuron.training_examples_per_miner",
             type=int,
             help="The number of rows to train on per miner",
-            default=500,
+            default=565,
         )
 
         parser.add_argument(

--- a/distributed_training/utils/config.py
+++ b/distributed_training/utils/config.py
@@ -115,7 +115,7 @@ def add_args(cls, parser):
         nargs="+",
         help="The addresses for the DHT",
         default=[
-            "/ip4/161.97.156.125/tcp/8000/p2p/12D3KooWQEW27pELHmYLLtxQEHm5v7t66CVJ6We1Z75kS9DC9KDz",
+            "/ip4/161.97.156.125/tcp/8000/p2p/12D3KooWGNAPtpTKVqkZSDtdJtQPv8MZrncj8syi6wgzEyBLq2FE",
         ],
     )
 

--- a/distributed_training/utils/config.py
+++ b/distributed_training/utils/config.py
@@ -130,7 +130,7 @@ def add_args(cls, parser):
         "--neuron.local_batch_size_train",
         type=int,
         help="The default batch size",
-        default=6,
+        default=4,
     )
 
     parser.add_argument(
@@ -175,13 +175,6 @@ def add_args(cls, parser):
     )
 
     if neuron_type == "validator":
-        parser.add_argument(
-            "--neuron.local_batch_size_test",
-            type=int,
-            help="The default batch size",
-            default=8,
-        )
-
         parser.add_argument(
             "--neuron.num_of_duplicates",
             type=int,

--- a/distributed_training/utils/uids.py
+++ b/distributed_training/utils/uids.py
@@ -151,27 +151,28 @@ async def map_uid_to_peerid(self, uids):
             uids_to_peerids[uid] = None
             continue
         else:
-            if peer_list_dht_addrs.count(miner_ip) > 1:
-                indices = [
-                    i
-                    for i in range(len(peer_list_dht_addrs))
-                    if peer_list_dht_addrs[i] == miner_ip
-                ]
-                peer_id = None
-                for index in indices:
-                    if abs(miner_port - int(peer_list_dht_ports[index])) < 10:
-                        peer_id = peer_list_dht[index].peer_id
-                        break
-                    elif index == indices[-1]:
-                        break
-                    else:
-                        continue
+            # if peer_list_dht_addrs.count(miner_ip) > 1:
+            #     indices = [
+            #         i
+            #         for i in range(len(peer_list_dht_addrs))
+            #         if peer_list_dht_addrs[i] == miner_ip
+            #     ]
+            #     peer_id = None
+            #     for index in indices:
+            #         if abs(miner_port - int(peer_list_dht_ports[index])) < 10:
+            #             peer_id = peer_list_dht[index].peer_id
+            #             break
+            #         elif index == indices[-1]:
+            #             break
+            #         else:
+            #             continue
 
-                if peer_id is None:
-                    uids_to_peerids[uid] = None
-                    continue
-            else:
-                peer_id = peer_list_dht[peer_list_dht_addrs.index(miner_ip)].peer_id
+            #     if peer_id is None:
+            #         uids_to_peerids[uid] = None
+            #         continue
+            # else:
+            #     peer_id = peer_list_dht[peer_list_dht_addrs.index(miner_ip)].peer_id
+            peer_id = peer_list_dht[peer_list_dht_addrs.index(miner_ip)].peer_id
 
         # If peer_id is not in the list of peer ids for our run then it is not connected to our run ID
         if str(peer_id) not in run_peer_id_list:

--- a/distributed_training/utils/uids.py
+++ b/distributed_training/utils/uids.py
@@ -114,26 +114,24 @@ async def get_random_uids(
 
 
 async def map_uid_to_peerid(self, uids):
+    # Get all peers connected to our DHT, their ips and their ports
+    peer_list_dht = await self._p2p.list_peers()
+    peer_list_dht_addrs = [
+        str(peer.addrs[0]).split("/ip4/")[1].split("/")[0] for peer in peer_list_dht
+    ]
+    peer_list_dht_ports = [str(peer.addrs[0]).split("/")[-1] for peer in peer_list_dht]
+
+    # Get only peers connected to the current run id
+    prefix = self.grad_averager.matchmaking_kwargs["prefix"]
+    metadata, _ = self.dht.get(f"{prefix}.all_averagers", latest=True) or (
+        {},
+        None,
+    )
+
     uids_to_peerids = {}
     for uid in uids:
         miner_ip = self.metagraph.axons[uid].ip
         miner_port = self.metagraph.axons[uid].port
-
-        # Get all peers connected to our DHT, their ips and their ports
-        peer_list_dht = await self._p2p.list_peers()
-        peer_list_dht_addrs = [
-            str(peer.addrs[0]).split("/ip4/")[1].split("/")[0] for peer in peer_list_dht
-        ]
-        peer_list_dht_ports = [
-            str(peer.addrs[0]).split("/")[-1] for peer in peer_list_dht
-        ]
-
-        # Get only peers connected to the current run id
-        prefix = self.grad_averager.matchmaking_kwargs["prefix"]
-        metadata, _ = self.dht.get(f"{prefix}.all_averagers", latest=True) or (
-            {},
-            None,
-        )
 
         if metadata is None:
             # return None

--- a/distributed_training/validator/forward.py
+++ b/distributed_training/validator/forward.py
@@ -73,254 +73,269 @@ async def forward(self):
         all_reduce = False
         self.event.update({"synapse_type": "train"})
 
-    # Get active miners
-    self.miner_uids = await get_random_uids(
-        self,
-        dendrite=self.dendrite,
-        k=sample_size,
-        epoch=self.local_progress.epoch if all_reduce else None,
-    )
-
-    self.event.update({"uids": self.miner_uids})
-    bt.logging.info(f"UIDs:  {self.miner_uids}")
-
-    if self.miner_uids.tolist() == []:
-        responses = [[]]
-        bt.logging.info("No Active Miners Found This Step.")
-    else:
-        query_tasks = []
-        if all_reduce:
-            bt.logging.info("Performing Gradient Averaging")
-            self.peerids_to_uids = {
-                str(value): key for key, value in self.uids_to_peerids.items()
-            }
-            gradient_averaging_step = self.grad_averager.step(
-                wait=False,
-            )
-            # peerids_to_uids = self.peerids_to_uids)
-            self.learning_rate = self.get_learning_rate()
-            bt.logging.info(f"Current Learning Rate: {self.learning_rate}")
-
-            queries = [
-                distributed_training.protocol.AllReduce(
-                    learning_rate=self.learning_rate
-                )
-                for _ in self.miner_uids
-            ]
-        else:
-            # Get a random layer to check gradients against
-            gradient_test_index = random.choice(self.test_layer_indices)
-            queries = [
-                distributed_training.protocol.Train(
-                    model_name=self.model.name_or_path,
-                    gradient_test_index=gradient_test_index,
-                )
-                for _ in self.miner_uids
-            ]
-
-        # Query the network
-        query_tasks.append(
-            self.dendrite_pool.async_forward(
-                self.miner_uids,
-                queries,
-                timeout=self.all_reduce_timeout if all_reduce else self.train_timeout,
-            )
+    if (self.uid == self.master_uid) or (all_reduce == False):
+        # Get active miners
+        self.miner_uids = await get_random_uids(
+            self,
+            dendrite=self.dendrite,
+            k=sample_size,
+            epoch=self.local_progress.epoch if all_reduce else None,
         )
-        bt.logging.info("Query Sent Out")
-        start_time = time.perf_counter()
-        responses = await asyncio.gather(*query_tasks)
-        bt.logging.info("Query Responses Received")
 
-        # Process the AllReduce query responses
-        if all_reduce and responses != [[]]:
-            failed_gradient_all_reduce = False
-            # Wait for gradient averaging to finish
-            while (gradient_averaging_step.done() is False) and (
-                (time.perf_counter() - start_time) <= self.all_reduce_timeout
-            ):
-                time.sleep(1)
+        self.event.update({"uids": self.miner_uids})
+        bt.logging.info(f"UIDs:  {self.miner_uids}")
 
-            if gradient_averaging_step.done():
-                # Optimizer Step
-                with self.grad_averager.use_averaged_gradients():
-                    # Log Model Weight Before Optimizer Step
-                    bt.logging.info("Model Weights Before Optimizer Step")
-                    current_model_weights_sample = copy.copy(
+        if self.miner_uids.tolist() == []:
+            responses = [[]]
+            bt.logging.info("No Active Miners Found This Step.")
+        else:
+            query_tasks = []
+            if all_reduce:
+                bt.logging.info("Performing Gradient Averaging")
+                self.peerids_to_uids = {
+                    str(value): key for key, value in self.uids_to_peerids.items()
+                }
+                gradient_averaging_step = self.grad_averager.step(
+                    wait=False,
+                )
+                # peerids_to_uids = self.peerids_to_uids)
+                self.learning_rate = self.get_learning_rate()
+                bt.logging.info(f"Current Learning Rate: {self.learning_rate}")
+
+                queries = [
+                    distributed_training.protocol.AllReduce(
+                        learning_rate=self.learning_rate
+                    )
+                    for _ in self.miner_uids
+                ]
+            else:
+                # Get a random layer to check gradients against
+                gradient_test_index = random.choice(self.test_layer_indices)
+                queries = [
+                    distributed_training.protocol.Train(
+                        model_name=self.model.name_or_path,
+                        gradient_test_index=gradient_test_index,
+                    )
+                    for _ in self.miner_uids
+                ]
+
+            # Query the network
+            query_tasks.append(
+                self.dendrite_pool.async_forward(
+                    self.miner_uids,
+                    queries,
+                    timeout=self.all_reduce_timeout
+                    if all_reduce
+                    else self.train_timeout,
+                )
+            )
+            bt.logging.info("Query Sent Out")
+            start_time = time.perf_counter()
+            responses = await asyncio.gather(*query_tasks)
+            bt.logging.info("Query Responses Received")
+
+            # Process the AllReduce query responses
+            if all_reduce and responses != [[]]:
+                failed_gradient_all_reduce = False
+                # Wait for gradient averaging to finish
+                while (gradient_averaging_step.done() is False) and (
+                    (time.perf_counter() - start_time) <= self.all_reduce_timeout
+                ):
+                    time.sleep(1)
+
+                if gradient_averaging_step.done():
+                    # Optimizer Step
+                    with self.grad_averager.use_averaged_gradients():
+                        # Log Model Weight Before Optimizer Step
+                        bt.logging.info("Model Weights Before Optimizer Step")
+                        current_model_weights_sample = copy.copy(
+                            [layer for layer in self.model.parameters()][-2][
+                                -10:
+                            ].tolist()
+                        )
+                        bt.logging.info(current_model_weights_sample)
+
+                        bt.logging.info("Model Gradients Before Clipping")
+                        # Copy gradients
+                        gradients = tuple(
+                            (
+                                param.grad.detach().cpu().clone()
+                                if param.grad is not None
+                                else torch.zeros_like(param)
+                            )
+                            for param in self.model.parameters()
+                        )
+                        bt.logging.info(gradients[-1][-10:].tolist())
+
+                        bt.logging.info("Clipping Grads")
+                        torch.nn.utils.clip_grad_norm_(self.model.parameters(), 1.0)
+
+                        bt.logging.info(
+                            "Model Gradients After Clipping Before Optimizer Step"
+                        )
+                        # Copy gradients
+                        gradients = tuple(
+                            (
+                                param.grad.detach().cpu().clone()
+                                if param.grad is not None
+                                else torch.zeros_like(param)
+                            )
+                            for param in self.model.parameters()
+                        )
+                        bt.logging.info(gradients[-1][-10:].tolist())
+
+                        bt.logging.info(
+                            f"Updating Optimizer Learning Rate To: {self.learning_rate}"
+                        )
+                        for param_group in self.opt.param_groups:
+                            param_group["lr"] = self.learning_rate
+
+                        # Update model parameters using averaged gradients
+                        bt.logging.info("Performing Optimizer Step")
+                        self.opt.step()
+
+                        # Reset gradient buffers
+                        self.grad_averager.reset_accumulated_grads_()
+
+                    # Log Model Weight After Optimizer Step
+                    bt.logging.info("Model Weights After Optimizer Step")
+                    new_model_weights_sample = copy.copy(
                         [layer for layer in self.model.parameters()][-2][-10:].tolist()
                     )
-                    bt.logging.info(current_model_weights_sample)
+                    bt.logging.info(new_model_weights_sample)
 
-                    bt.logging.info("Model Gradients Before Clipping")
-                    # Copy gradients
-                    gradients = tuple(
-                        (
-                            param.grad.detach().cpu().clone()
-                            if param.grad is not None
-                            else torch.zeros_like(param)
+                    if new_model_weights_sample == current_model_weights_sample:
+                        bt.logging.info(
+                            "Averaging Failed. Model Weights Haven't Changed. Loading Latest Model State."
                         )
-                        for param in self.model.parameters()
-                    )
-                    bt.logging.info(gradients[-1][-10:].tolist())
+                        failed_gradient_all_reduce = True
+                        load_state_from_peer(self, epoch=self.local_progress.epoch + 1)
 
-                    bt.logging.info("Clipping Grads")
-                    torch.nn.utils.clip_grad_norm_(self.model.parameters(), 1.0)
-
-                    bt.logging.info(
-                        "Model Gradients After Clipping Before Optimizer Step"
-                    )
-                    # Copy gradients
-                    gradients = tuple(
-                        (
-                            param.grad.detach().cpu().clone()
-                            if param.grad is not None
-                            else torch.zeros_like(param)
+                    elif sum(np.isnan(new_model_weights_sample)) > 1:
+                        bt.logging.info(
+                            "Averaging Failed. Model Weights Corrupted With NaNs After Running The Optimizer Step. Loading Latest Model State."
                         )
-                        for param in self.model.parameters()
-                    )
-                    bt.logging.info(gradients[-1][-10:].tolist())
-
-                    bt.logging.info(
-                        f"Updating Optimizer Learning Rate To: {self.learning_rate}"
-                    )
-                    for param_group in self.opt.param_groups:
-                        param_group["lr"] = self.learning_rate
-
-                    # Update model parameters using averaged gradients
-                    bt.logging.info("Performing Optimizer Step")
-                    self.opt.step()
-
-                    # Reset gradient buffers
-                    self.grad_averager.reset_accumulated_grads_()
-
-                # Log Model Weight After Optimizer Step
-                bt.logging.info("Model Weights After Optimizer Step")
-                new_model_weights_sample = copy.copy(
-                    [layer for layer in self.model.parameters()][-2][-10:].tolist()
-                )
-                bt.logging.info(new_model_weights_sample)
-
-                if new_model_weights_sample == current_model_weights_sample:
-                    bt.logging.info(
-                        "Averaging Failed. Model Weights Haven't Changed. Loading Latest Model State."
-                    )
-                    failed_gradient_all_reduce = True
-                    load_state_from_peer(self, epoch=self.local_progress.epoch + 1)
-
-                elif sum(np.isnan(new_model_weights_sample)) > 1:
-                    bt.logging.info(
-                        "Averaging Failed. Model Weights Corrupted With NaNs After Running The Optimizer Step. Loading Latest Model State."
-                    )
-                    failed_gradient_all_reduce = True
-                    state_loaded = load_state_from_peer(
-                        self, epoch=self.local_progress.epoch + 1
-                    )
-                    if not state_loaded:
+                        failed_gradient_all_reduce = True
                         state_loaded = load_state_from_peer(
-                            self, epoch=self.local_progress.epoch
+                            self, epoch=self.local_progress.epoch + 1
                         )
+                        if not state_loaded:
+                            state_loaded = load_state_from_peer(
+                                self, epoch=self.local_progress.epoch
+                            )
+
+                    else:
+                        # Update local progress
+                        self.local_progress.epoch += 1
+                        self.local_progress.samples_accumulated = 0
+
+                        # Push to HF Hub if the current validator is the first to update
+                        refs = list_repo_refs(
+                            self.config.neuron.model_name, repo_type="model"
+                        )
+                        tag_name = (
+                            max([int(tag.name) for tag in refs.tags])
+                            if refs.tags
+                            else None
+                        )
+                        bt.logging.info(f"Old Model Tag {tag_name}")
+                        if (
+                            tag_name is not None
+                        ) and tag_name < self.local_progress.epoch:
+                            attempt = 0
+                            while attempt < self.model_upload_retry_limit:
+                                try:
+                                    bt.logging.info(
+                                        "Pushing New Model Weights To HF Hub."
+                                    )
+                                    self.model.push_to_hub(
+                                        self.config.neuron.model_name,
+                                        commit_message=f"Epoch {self.local_progress.epoch}",
+                                    )
+                                    create_tag(
+                                        self.config.neuron.model_name,
+                                        repo_type="model",
+                                        tag=str(self.local_progress.epoch),
+                                        tag_message=f"Epoch {self.local_progress.epoch}",
+                                    )
+                                    refs = list_repo_refs(
+                                        self.config.neuron.model_name, repo_type="model"
+                                    )
+                                    tag_name = max([int(tag.name) for tag in refs.tags])
+                                    bt.logging.info(f"New Model Tag {tag_name}")
+                                    break
+
+                                except HfHubHTTPError:
+                                    bt.logging.info(
+                                        f"Model With Tag {tag_name} Already Uploaded to HF Hub. Loading That Model."
+                                    )
+                                    state_loaded = load_state_from_peer(
+                                        self, epoch=tag_name
+                                    )
+                                    if state_loaded:
+                                        break
+                                except Exception as e:
+                                    attempt += 1
+                                    bt.logging.warning(
+                                        f"Failed To Upload Model To HF hub, Retrying. Attempt {attempt}/{self.model_upload_retry_limit}."
+                                    )
+                                    if attempt < self.model_upload_retry_limit:
+                                        # Wait before the next retry
+                                        time.sleep(self.model_upload_retry_delay)
+                                    else:
+                                        bt.logging.error(
+                                            "Maximum Retry Limit Reached. Unable To Upload Model To HF Hub."
+                                        )
+                                        raise
 
                 else:
-                    # Update local progress
-                    self.local_progress.epoch += 1
-                    self.local_progress.samples_accumulated = 0
+                    bt.logging.info("Averaging Failed. Loading Latest Model State.")
+                    failed_gradient_all_reduce = True
+                    load_state_from_peer(self)
 
-                    # Push to HF Hub if the current validator is the first to update
-                    refs = list_repo_refs(
-                        self.config.neuron.model_name, repo_type="model"
-                    )
-                    tag_name = (
-                        max([int(tag.name) for tag in refs.tags]) if refs.tags else None
-                    )
-                    bt.logging.info(f"Old Model Tag {tag_name}")
-                    if (tag_name is not None) and tag_name < self.local_progress.epoch:
-                        attempt = 0
-                        while attempt < self.model_upload_retry_limit:
-                            try:
-                                bt.logging.info("Pushing New Model Weights To HF Hub.")
-                                self.model.push_to_hub(
-                                    self.config.neuron.model_name,
-                                    commit_message=f"Epoch {self.local_progress.epoch}",
-                                )
-                                create_tag(
-                                    self.config.neuron.model_name,
-                                    repo_type="model",
-                                    tag=str(self.local_progress.epoch),
-                                    tag_message=f"Epoch {self.local_progress.epoch}",
-                                )
-                                refs = list_repo_refs(
-                                    self.config.neuron.model_name, repo_type="model"
-                                )
-                                tag_name = max([int(tag.name) for tag in refs.tags])
-                                bt.logging.info(f"New Model Tag {tag_name}")
-                                break
+                if failed_gradient_all_reduce:
+                    gradient_averaging_step.cancel()
+                    bt.logging.info("Gradient Step Cancelled")
+                    with self.grad_averager.use_averaged_gradients():
+                        self.opt.zero_grad()
+                    bt.logging.info("Optimizer Gradients Zeroed")
 
-                            except HfHubHTTPError:
-                                bt.logging.info(
-                                    f"Model With Tag {tag_name} Already Uploaded to HF Hub. Loading That Model."
-                                )
-                                state_loaded = load_state_from_peer(
-                                    self, epoch=tag_name
-                                )
-                                if state_loaded:
-                                    break
-                            except Exception as e:
-                                attempt += 1
-                                bt.logging.warning(
-                                    f"Failed To Upload Model To HF hub, Retrying. Attempt {attempt}/{self.model_upload_retry_limit}."
-                                )
-                                if attempt < self.model_upload_retry_limit:
-                                    # Wait before the next retry
-                                    time.sleep(self.model_upload_retry_delay)
-                                else:
-                                    bt.logging.error(
-                                        "Maximum Retry Limit Reached. Unable To Upload Model To HF Hub."
-                                    )
-                                    raise
-
+                self.step_scheduled = False
+            # Process the Train query responses
             else:
-                bt.logging.info("Averaging Failed. Loading Latest Model State.")
-                failed_gradient_all_reduce = True
-                load_state_from_peer(self)
-
-            if failed_gradient_all_reduce:
-                gradient_averaging_step.cancel()
-                bt.logging.info("Gradient Step Cancelled")
-                with self.grad_averager.use_averaged_gradients():
-                    self.opt.zero_grad()
-                bt.logging.info("Optimizer Gradients Zeroed")
-
-            self.step_scheduled = False
-        # Process the Train query responses
-        else:
-            bt.logging.info(
-                "Received Responses: "
-                + str(
+                bt.logging.info(
+                    "Received Responses: "
+                    + str(
+                        [
+                            {
+                                "Loss": response.loss,
+                                "Dataset Indices": (
+                                    min(response.dataset_indices),
+                                    max(response.dataset_indices),
+                                ),
+                                "IP": self.metagraph.axons[uid].ip,
+                                "Port": self.metagraph.axons[uid].port,
+                                "Hotkey": self.metagraph.axons[uid].hotkey,
+                            }
+                            for response, uid in zip(responses[0], self.miner_uids)
+                            if response.dendrite.status_code == 200
+                            and (response.dataset_indices is not None)
+                        ]
+                    )
+                )
+                self.average_loss = np.array(
                     [
-                        {
-                            "Loss": response.loss,
-                            "Dataset Indices": (
-                                min(response.dataset_indices),
-                                max(response.dataset_indices),
-                            ),
-                            "IP": self.metagraph.axons[uid].ip,
-                            "Port": self.metagraph.axons[uid].port,
-                            "Hotkey": self.metagraph.axons[uid].hotkey,
-                        }
+                        response.loss
                         for response, uid in zip(responses[0], self.miner_uids)
                         if response.dendrite.status_code == 200
                         and (response.dataset_indices is not None)
                     ]
-                )
-            )
-            self.average_loss = np.array(
-                [
-                    response.loss
-                    for response, uid in zip(responses[0], self.miner_uids)
-                    if response.dendrite.status_code == 200
-                    and (response.dataset_indices is not None)
-                ]
-            ).mean()
-            bt.logging.info(f"Current Average Miner Loss: {self.average_loss}")
+                ).mean()
+                bt.logging.info(f"Current Average Miner Loss: {self.average_loss}")
+
+    else:
+        time.sleep(self.all_reduce_timeout + 30)
+        self.miner_uids = []
 
     # Adjust the scores based on responses from miners.
     rewards = await get_rewards(

--- a/distributed_training/validator/forward.py
+++ b/distributed_training/validator/forward.py
@@ -79,7 +79,7 @@ async def forward(self):
     if (self.uid == self.master_uid) or (all_reduce == False):
         if all_reduce:
             # Get active miners
-            while len(self.miner_uids) < 2:
+            while len(self.miner_uids) < 10:
                 bt.logging.info(
                     f"Found {len(self.miner_uids)} UIDs. Attempting to find {10-len(self.miner_uids)} more UIDs."
                 )

--- a/distributed_training/validator/forward.py
+++ b/distributed_training/validator/forward.py
@@ -121,7 +121,9 @@ async def forward(self):
         # Query the network
         query_tasks.append(
             self.dendrite_pool.async_forward(
-                self.miner_uids, queries, timeout=self.all_reduce_timeout
+                self.miner_uids,
+                queries,
+                timeout=self.all_reduce_timeout if all_reduce else self.train_timeout,
             )
         )
         bt.logging.info("Query Sent Out")

--- a/distributed_training/validator/forward.py
+++ b/distributed_training/validator/forward.py
@@ -59,7 +59,6 @@ async def forward(self):
             )
             <= 25
         )
-        and (not self.step_scheduled)
         and (self.global_progress.epoch == self.local_progress.epoch)
     ):
         # If running an AllReduce synapse, call as many miners as possible
@@ -300,7 +299,66 @@ async def forward(self):
                         self.opt.zero_grad()
                     bt.logging.info("Optimizer Gradients Zeroed")
 
-                self.step_scheduled = False
+                # if failed_gradient_all_reduce: 
+                #     all_reduce = False
+                #     self.event.update({"synapse_type": "train"})
+
+                #     # Get a random layer to check gradients against
+                #     gradient_test_index = random.choice(self.test_layer_indices)
+                #     queries = [
+                #         distributed_training.protocol.Train(
+                #             model_name=self.model.name_or_path,
+                #             gradient_test_index=gradient_test_index,
+                #         )
+                #         for _ in self.miner_uids
+                #     ]
+                    
+                #     query_tasks = []
+                #     # Query the network
+                #     query_tasks.append(
+                #         self.dendrite_pool.async_forward(
+                #             self.miner_uids,
+                #             queries,
+                #             timeout=self.all_reduce_timeout
+                #             if all_reduce
+                #             else self.train_timeout,
+                #         )
+                #     )
+                #     bt.logging.info("Query Sent Out")
+                #     start_time = time.perf_counter()
+                #     responses = await asyncio.gather(*query_tasks)
+                #     bt.logging.info("Query Responses Received")
+
+                #     bt.logging.info(
+                #         "Received Responses: "
+                #         + str(
+                #             [
+                #                 {
+                #                     "Loss": response.loss,
+                #                     "Dataset Indices": (
+                #                         min(response.dataset_indices),
+                #                         max(response.dataset_indices),
+                #                     ),
+                #                     "IP": self.metagraph.axons[uid].ip,
+                #                     "Port": self.metagraph.axons[uid].port,
+                #                     "Hotkey": self.metagraph.axons[uid].hotkey,
+                #                 }
+                #                 for response, uid in zip(responses[0], self.miner_uids)
+                #                 if response.dendrite.status_code == 200
+                #                 and (response.dataset_indices is not None)
+                #             ]
+                #         )
+                #     )
+                #     self.average_loss = np.array(
+                #         [
+                #             response.loss
+                #             for response, uid in zip(responses[0], self.miner_uids)
+                #             if response.dendrite.status_code == 200
+                #             and (response.dataset_indices is not None)
+                #         ]
+                #     ).mean()
+                #     bt.logging.info(f"Current Average Miner Loss: {self.average_loss}")
+
             # Process the Train query responses
             else:
                 bt.logging.info(

--- a/distributed_training/validator/forward.py
+++ b/distributed_training/validator/forward.py
@@ -81,7 +81,7 @@ async def forward(self):
             # Get active miners
             while len(self.miner_uids) < 2:
                 bt.logging.info(
-                    f"Only {len(self.miner_uids)} uids found. Attempting to find {4-len(self.miner_uids)} more uids"
+                    f"Found {len(self.miner_uids)} UIDs. Attempting to find {10-len(self.miner_uids)} more UIDs."
                 )
                 self.miner_uids = await get_random_uids(
                     self,

--- a/distributed_training/validator/reward.py
+++ b/distributed_training/validator/reward.py
@@ -156,7 +156,7 @@ async def get_rewards(
     - torch.FloatTensor: A tensor of rewards for the given query and responses.
     """
     # Score a non-empty AllReduce response
-    if all_reduce and (responses != [[]]):
+    if all_reduce and ((responses != [[]]) or (self.uid != self.master_uid)):
         # Now that we've called all_reduce on all available UIDs, only score a sample of them to spread
         # the scoring burden across all validators
         self.miner_uids = await get_random_uids(

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -142,7 +142,13 @@ class Miner(BaseMinerNeuron):
             compression=hivemind.Uniform8BitQuantization(),
             accumulate_grads_on=torch.device(self.device),
             start=True,
-            next_chunk_timeout=30.0,
+            min_group_size=10,
+            min_matchmaking_time=30.0,
+            request_timeout=15.0,
+            allreduce_timeout=None,
+            next_chunk_timeout=None,
+            sender_timeout=None,
+            reducer_timeout=None,
         )
 
         self.loop = asyncio.new_event_loop()
@@ -323,9 +329,6 @@ class Miner(BaseMinerNeuron):
         if failed_gradient_all_reduce:
             gradient_averaging_step.cancel()
             bt.logging.info("Gradient Step Cancelled")
-            with self.grad_averager.use_averaged_gradients():
-                self.opt.zero_grad()
-            bt.logging.info("Optimizer Gradients Zeroed")
 
         return synapse
 

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -142,7 +142,7 @@ class Miner(BaseMinerNeuron):
             compression=hivemind.Uniform8BitQuantization(),
             accumulate_grads_on=torch.device(self.device),
             start=True,
-            min_group_size=10,
+            min_group_size=5,
             min_matchmaking_time=30.0,
             request_timeout=15.0,
             allreduce_timeout=None,

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -153,10 +153,13 @@ class Validator(BaseValidatorNeuron):
 
         # Init UID
         self.uid = self.metagraph.hotkeys.index(self.wallet.hotkey.ss58_address)
+        self.master_uid = self.metagraph.hotkeys.index(
+            "5EnC86fRRRoaXUZvkrDFYpAihuyEAp3wGkY5r3Gak1kPTDVP"
+        )
 
         # Init All Reduce Variables
         self.train_timeout = 100
-        self.all_reduce_timeout = 120
+        self.all_reduce_timeout = 240
         self.step_scheduled = False
         self.model_upload_retry_limit = 3
         self.model_upload_retry_delay = 10

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -155,7 +155,8 @@ class Validator(BaseValidatorNeuron):
         self.uid = self.metagraph.hotkeys.index(self.wallet.hotkey.ss58_address)
 
         # Init All Reduce Variables
-        self.all_reduce_timeout = 300
+        self.train_timeout = 100
+        self.all_reduce_timeout = 120
         self.step_scheduled = False
         self.model_upload_retry_limit = 3
         self.model_upload_retry_delay = 10

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -162,9 +162,9 @@ class Validator(BaseValidatorNeuron):
         self.all_reduce_timeout = 300
         self.model_upload_retry_limit = 3
         self.model_upload_retry_delay = 10
-        self.maximum_steps = 19_073  # 10_000_000_000/(512*1024)
-        self.warmup_steps = 715  # 38_146 * 0.03
-        self.learning_rate_maximum = 6e-4
+        self.maximum_steps = 306 * 4  # 10_000_000_000/(32000*1024)
+        self.warmup_steps = 62  # 306 / 5
+        self.learning_rate_maximum = 0.0025
         self.learning_rate = self.get_learning_rate()
         self.average_loss = None
         self.weight_decay = 0.1
@@ -192,7 +192,13 @@ class Validator(BaseValidatorNeuron):
             compression=hivemind.Uniform8BitQuantization(),
             accumulate_grads_on=torch.device("cuda"),
             start=True,
-            next_chunk_timeout=30.0,
+            min_group_size=10,
+            min_matchmaking_time=30.0,
+            request_timeout=15.0,
+            allreduce_timeout=None,
+            next_chunk_timeout=None,
+            sender_timeout=None,
+            reducer_timeout=None,
         )
 
         self.loop = asyncio.new_event_loop()

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -159,8 +159,7 @@ class Validator(BaseValidatorNeuron):
 
         # Init All Reduce Variables
         self.train_timeout = 100
-        self.all_reduce_timeout = 240
-        self.step_scheduled = False
+        self.all_reduce_timeout = 300
         self.model_upload_retry_limit = 3
         self.model_upload_retry_delay = 10
         self.maximum_steps = 19_073  # 10_000_000_000/(512*1024)

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -192,7 +192,7 @@ class Validator(BaseValidatorNeuron):
             compression=hivemind.Uniform8BitQuantization(),
             accumulate_grads_on=torch.device("cuda"),
             start=True,
-            min_group_size=10,
+            min_group_size=5,
             min_matchmaking_time=30.0,
             request_timeout=15.0,
             allreduce_timeout=None,


### PR DESCRIPTION
To-Do:
- [x] Fix the error where the system gets stuck in a loop if validators fail an all-reduce but miners succeed. Currently the system re-attempts an all reduce when all miners have already averaged their gradients, applied opt.step() and zeroed their gradients
- [x] Add in a try catch for when model loading from HF fails due to HF server errors
- [x] Fix the error where miners or validators that fail an all-reduce seem to hang and not print out this statement: https://github.com/KMFODA/DistributedTraining/blob/51d10689b277162225805811b9cc3b1d7789dadd/neurons/miner.py#L328
- [x] Increase the `min_matchmaking_time` and the `min_group_size` averager variables as we aim to transition to 32k batch sizes and beyond
- [x] Merge https://huggingface.co/distributed/optimized-gpt2-250m/discussions/1 into the new model