### PR TITLE
Upgrade to Bittensor v8.5.1

### DIFF
--- a/distributed_training/__init__.py
+++ b/distributed_training/__init__.py
@@ -17,7 +17,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 # version nomenclature = __training_type__.__model__.__other_changes__
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 __run__ = "1"
 version_split = __version__.split(".")
 __spec_version__ = (

--- a/distributed_training/utils/state_loader.py
+++ b/distributed_training/utils/state_loader.py
@@ -4,10 +4,9 @@ import time
 import logging
 import tempfile
 import threading
-from typing import Dict, Sequence
+from typing import Dict
 
 import bittensor as bt
-import bitsandbytes
 import torch
 from hivemind.utils import get_logger
 from huggingface_hub import hf_hub_download, scan_cache_dir, create_tag, upload_folder
@@ -268,39 +267,3 @@ def save_and_upload_state(self, epoch, batch_size, participating_peers, failed_p
                 )
                 raise
     return False
-
-
-def replace_embeddings_with_stable(model):
-    """
-    Replace standard embeddings with StableEmbedding in a pre-initialized model.
-
-    Args:
-        model: The initialized GPTOptim model
-    """
-    # Get current embeddings' parameters
-    wte_config = {
-        "num_embeddings": model.model.transformer.wte.num_embeddings,
-        "embedding_dim": model.model.transformer.wte.embedding_dim,
-    }
-    wpe_config = {
-        "num_embeddings": model.model.transformer.wpe.num_embeddings,
-        "embedding_dim": model.model.transformer.wpe.embedding_dim,
-    }
-
-    # Create new StableEmbedding layers
-    new_wte = bitsandbytes.nn.StableEmbedding(**wte_config)
-    new_wpe = bitsandbytes.nn.StableEmbedding(**wpe_config)
-
-    # Copy existing weights
-    with torch.no_grad():
-        new_wte.weight.copy_(model.model.transformer.wte.weight.data)
-        new_wpe.weight.copy_(model.model.transformer.wpe.weight.data)
-
-    # Replace embeddings
-    model.model.transformer.wte = new_wte
-    model.model.transformer.wpe = new_wpe
-
-    # Update weight tying for language model head
-    model.model.lm_head.weight = model.model.transformer.wte.weight
-
-    return model

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -49,7 +49,6 @@ from distributed_training.utils.gradient_averager import (
 from distributed_training.utils.state_loader import (
     load_state_from_peer,
     ModelLoadingManager,
-    replace_embeddings_with_stable,
 )
 
 from distributed_training.utils.chain import log_peerid_to_chain
@@ -141,7 +140,6 @@ class Miner(BaseMinerNeuron):
                 self.config.neuron.model_name, trust_remote_code=True
             )
         )
-        self.model = replace_embeddings_with_stable(self.model)
 
         # Move the model to the appropriate device
         self.model = self.model.to(self.device)

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -25,11 +25,13 @@ from typing import Optional
 os.environ["NEST_ASYNCIO"] = "0"
 import math
 
+import bitsandbytes
 import bittensor as bt
 import torch
 import threading
 from bitarray import bitarray
 from bitsandbytes.optim import LAMB8bit
+from bitsandbytes.cextension import lib
 from transformers import AutoModelForCausalLM
 
 import hivemind
@@ -52,6 +54,7 @@ from distributed_training.utils.progress_tracker import (
 from distributed_training.utils.state_loader import (
     load_state_from_peer,
     ModelLoadingManager,
+    replace_embeddings_with_stable,
 )
 from distributed_training.utils.uids import (
     map_uid_to_peerid,
@@ -66,6 +69,14 @@ from hivemind.utils.asyncio import aiter_with_timeout
 from hivemind.utils.streaming import combine_from_streaming
 
 from huggingface_hub import hf_hub_download
+
+# Add lamb to bnb str2optimizer8bit_blockwise
+bitsandbytes.functional.str2optimizer8bit_blockwise
+bitsandbytes.functional.str2optimizer8bit_blockwise["lamb"] = (
+    lib.cadam_8bit_blockwise_grad_fp32,
+    lib.cadam_8bit_blockwise_grad_fp16,
+    lib.cadam_8bit_blockwise_grad_bf16,
+)
 
 logger = get_logger(__name__)
 
@@ -143,6 +154,7 @@ class Validator(BaseValidatorNeuron):
                 self.config.neuron.model_name, trust_remote_code=True
             )
         )
+        self.model = replace_embeddings_with_stable(self.model)
 
         # Move the model to the appropriate device
         self.model.to(self.device)
@@ -201,6 +213,7 @@ class Validator(BaseValidatorNeuron):
                 lr=optimizer_state["learning_rate"],
                 betas=(0.9, 0.95),
                 eps=1e-8,
+                block_wise=True,
             )
 
             self.opt.load_state_dict(optimizer_state["optimizer_state_dict"])
@@ -221,6 +234,7 @@ class Validator(BaseValidatorNeuron):
                 lr=self.learning_rate_maximum,
                 betas=(0.9, 0.95),
                 eps=1e-8,
+                block_wise=True,
             )
         # Init Gradient Averager
         self.grad_averager = DTGradientAverager(

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -54,7 +54,6 @@ from distributed_training.utils.progress_tracker import (
 from distributed_training.utils.state_loader import (
     load_state_from_peer,
     ModelLoadingManager,
-    replace_embeddings_with_stable,
 )
 from distributed_training.utils.uids import (
     map_uid_to_peerid,
@@ -154,7 +153,6 @@ class Validator(BaseValidatorNeuron):
                 self.config.neuron.model_name, trust_remote_code=True
             )
         )
-        self.model = replace_embeddings_with_stable(self.model)
 
         # Move the model to the appropriate device
         self.model.to(self.device)

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ def custom_command():
             "git+https://github.com/learning-at-home/hivemind.git@3a4cc15e29ce51b20c5d415a4c579abbae435718",
         ]
     )
-    pip.main(["install", "bittensor==8.5.0"])
+    pip.main(["install", "bittensor==8.5.1"])
     pip.main(["install", "py-multihash==2.0.1"])
 
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ def custom_command():
             "git+https://github.com/learning-at-home/hivemind.git@3a4cc15e29ce51b20c5d415a4c579abbae435718",
         ]
     )
-    pip.main(["install", "bittensor==8.2.1"])
+    pip.main(["install", "bittensor==8.5.0"])
     pip.main(["install", "py-multihash==2.0.1"])
 
 


### PR DESCRIPTION
If merged the following PR will do the following:

- [x] Upgrade Bittensor to v8.5.1 which should resolve the SSL / EOF errors
- [x] Update the LamB8bit optimizer to use block_wise quantisation which should improve convergence
- [x] Update the model being trained to used StableEmbeddings which should also improve convergence