### PR TITLE
Correctly Reload Optimizer and Schedulers For Failed Averagers & Late Joiners

### DIFF
--- a/distributed_training/__init__.py
+++ b/distributed_training/__init__.py
@@ -17,7 +17,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 # version nomenclature = __training_type__.__model__.__other_changes__
-__version__ = "1.0.9"
+__version__ = "1.0.10"
 __run__ = "2"
 version_split = __version__.split(".")
 __spec_version__ = (

--- a/distributed_training/__init__.py
+++ b/distributed_training/__init__.py
@@ -18,7 +18,7 @@
 
 # version nomenclature = __training_type__.__model__.__other_changes__
 __version__ = "1.0.9"
-__run__ = "1"
+__run__ = "2"
 version_split = __version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))

--- a/distributed_training/averaging/averagers.py
+++ b/distributed_training/averaging/averagers.py
@@ -667,11 +667,11 @@ class DTStateAverager(TrainingStateAverager):
             **kwargs
         )  # we specifically don't pass the scheduler here, default TrainingStateAverager would use it with the outer optimizer and we w
 
-    def reset_main_parameters(self, model_name, epoch):
+    def reset_main_parameters(self, model_name, revision):
         """Reset the optimizer parameteres to the parameters at the start of the epoch"""
         try:
             main_parameters = AutoModelForCausalLM.from_pretrained(
-                model_name, revision=str(epoch), trust_remote_code=True
+                model_name, revision=revision, trust_remote_code=True
             )
             opt_parameters = [
                 param
@@ -682,5 +682,5 @@ class DTStateAverager(TrainingStateAverager):
                 tuple(main_parameters.parameters()), opt_parameters
             ):
                 opt_param.data.copy_(main_param.data, non_blocking=True)
-        except:
-            bt.logging.info("Failed to reset optimizer parameters")
+        except Exception as e:
+            bt.logging.info(f"Failed to reset optimizer parameters with error: {e}")

--- a/distributed_training/averaging/averagers.py
+++ b/distributed_training/averaging/averagers.py
@@ -6,6 +6,7 @@ from typing import Any, AsyncIterator, Dict, Iterator, List, Optional, Union
 import bittensor as bt
 import hivemind
 import torch
+from transformers import AutoModelForCausalLM
 from hivemind.averaging.allreduce import (
     AllreduceException,
     AllReduceRunner,
@@ -666,10 +667,20 @@ class DTStateAverager(TrainingStateAverager):
             **kwargs
         )  # we specifically don't pass the scheduler here, default TrainingStateAverager would use it with the outer optimizer and we w
 
-    def update_main_param_after_outer_step(self):
-        """Update the main parameters with the inner optimizer step"""
-        opt_parameters = [
-            param for group in self.optimizer.param_groups for param in group["params"]
-        ]
-        for main_param, opt_param in zip(self.main_parameters, opt_parameters):
-            main_param.data.copy_(opt_param.data, non_blocking=True)
+    def reset_main_parameters(self, model_name, epoch):
+        """Reset the optimizer parameteres to the parameters at the start of the epoch"""
+        try:
+            main_parameters = AutoModelForCausalLM.from_pretrained(
+                model_name, revision=str(epoch), trust_remote_code=True
+            )
+            opt_parameters = [
+                param
+                for group in self.optimizer.param_groups
+                for param in group["params"]
+            ]
+            for main_param, opt_param in zip(
+                tuple(main_parameters.parameters()), opt_parameters
+            ):
+                opt_param.data.copy_(main_param.data, non_blocking=True)
+        except:
+            bt.logging.info("Failed to reset optimizer parameters")

--- a/distributed_training/base/miner.py
+++ b/distributed_training/base/miner.py
@@ -169,12 +169,17 @@ class BaseMinerNeuron(BaseNeuron):
                             bt.logging.info(
                                 f"Local Epoch {self.local_progress.epoch} Behind Global Epoch {self.global_progress.epoch}. Loading Latest Model State."
                             )
-                            load_state_from_peer(self, epoch=self.global_progress.epoch)
+                            load_state_from_peer(
+                                self,
+                                epoch=self.global_progress.epoch,
+                                reload_inner_optimizer=False,
+                            )
                         else:
                             load_state_from_peer(
                                 self,
                                 repo_id=self.config.neuron.local_model_name,
                                 epoch=self.global_progress.epoch,
+                                reload_inner_optimizer=False,
                             )
                         self.resume_training()
                         self.all_reduce_success_status = True

--- a/distributed_training/base/validator.py
+++ b/distributed_training/base/validator.py
@@ -185,7 +185,6 @@ class BaseValidatorNeuron(BaseNeuron):
                         and (self.global_progress.epoch != current_global_epoch)
                         and (self.should_all_reduce)
                     ):
-                        update_all_reduce_scores(self)
                         update_total_scores(self)
 
                 # Run multiple forwards concurrently.
@@ -296,6 +295,7 @@ class BaseValidatorNeuron(BaseNeuron):
         bt.logging.info(raw_weights)
         bt.logging.info(f"raw_weights: {raw_weights}")
         bt.logging.info(f"raw_weight_uids: {self.metagraph.uids.tolist()}")
+
         # Process the raw weights to final_weights via subtensor limitations.
         (
             processed_weight_uids,

--- a/distributed_training/utils/config.py
+++ b/distributed_training/utils/config.py
@@ -147,7 +147,7 @@ def add_args(cls, parser, prefix=None):
         "--neuron.blocks_per_allreduce",
         type=int,
         help="Amount of blocks between each all reduce",
-        default=3600,
+        default=800,
     )
 
     parser.add_argument(
@@ -189,7 +189,7 @@ def add_args(cls, parser, prefix=None):
         "--neuron.target_n_blocks",
         type=int,
         help="The hivemind global target_batch_size",
-        default=10,
+        default=5,
     )
 
     parser.add_argument(

--- a/distributed_training/utils/misc.py
+++ b/distributed_training/utils/misc.py
@@ -159,7 +159,7 @@ class AsyncDendritePool:
 def load_wandb(self, config, wallet, neuron_type, peer_id):
     run_name = f"{neuron_type[0].upper()}{'{:03}'.format(self.uid)}"
 
-    tags = [peer_id, self.wallet.hotkey.ss58_address, __version__, __run__]
+    tags = [peer_id, self.wallet.hotkey.ss58_address, __version__, f"r{__run__}"]
 
     run_id = "_".join([run_name] + tags[1:]).lower()
 

--- a/distributed_training/utils/misc.py
+++ b/distributed_training/utils/misc.py
@@ -159,7 +159,7 @@ class AsyncDendritePool:
 def load_wandb(self, config, wallet, neuron_type, peer_id):
     run_name = f"{neuron_type[0].upper()}{'{:03}'.format(self.uid)}"
 
-    tags = [peer_id, self.wallet.hotkey.ss58_address, __version__, f"r{__run__}"]
+    tags = [peer_id, self.wallet.hotkey.ss58_address, __version__, f"run{__run__}"]
 
     run_id = "_".join([run_name] + tags[1:]).lower()
 

--- a/distributed_training/utils/progress_tracker.py
+++ b/distributed_training/utils/progress_tracker.py
@@ -42,12 +42,12 @@ def get_global_epoch(self):
                 ]
             )
             if refs.tags
-            else None
+            else 0
         )
         return global_epoch
     except Exception as e:
         bt.logging.warning(f"Error in get_global_epoch: {str(e)}")
-        return None
+        return 0
 
 
 def get_local_epoch(self, repo_id: str = None):
@@ -68,12 +68,12 @@ def get_local_epoch(self, repo_id: str = None):
                 ]
             )
             if refs.tags
-            else None
+            else 0
         )
         return local_epoch
     except Exception as e:
         bt.logging.warning(f"Error in get_local_epoch: {str(e)}")
-        return None
+        return 0
 
 
 def get_local_inner_steps(self, repo_id: str = None):

--- a/distributed_training/utils/progress_tracker.py
+++ b/distributed_training/utils/progress_tracker.py
@@ -29,7 +29,11 @@ class LocalTrainingProgress(BaseModel):
 def get_global_epoch(self):
     try:
         refs = list_repo_refs(self.config.neuron.global_model_name, repo_type="model")
-        global_epoch = max([int(tag.name) for tag in refs.tags]) if refs.tags else None
+        global_epoch = (
+            max([int(tag.name.split(".")[0]) for tag in refs.tags])
+            if refs.tags
+            else None
+        )
         return global_epoch
     except Exception as e:
         bt.logging.warning(f"Error in get_global_epoch: {str(e)}")
@@ -42,7 +46,11 @@ def get_local_epoch(self, repo_id: str = None):
 
     try:
         refs = list_repo_refs(repo_id, repo_type="model")
-        local_epoch = max([int(tag.name) for tag in refs.tags]) if refs.tags else None
+        local_epoch = (
+            max([int(tag.name.split(".")[0]) for tag in refs.tags])
+            if refs.tags
+            else None
+        )
         return local_epoch
     except Exception as e:
         bt.logging.warning(f"Error in get_local_epoch: {str(e)}")

--- a/distributed_training/utils/progress_tracker.py
+++ b/distributed_training/utils/progress_tracker.py
@@ -34,12 +34,11 @@ def get_global_epoch(self):
             max(
                 [
                     int(tag.name.split(".")[1])
+                    for tag in refs.tags
                     if (
-                        (tag.name.split(".") == 3)
+                        (len(tag.name.split(".")) == 3)
                         and (tag.name.split(".")[0] == __run__)
                     )
-                    else int(tag.name)
-                    for tag in refs.tags
                 ]
             )
             if refs.tags
@@ -61,12 +60,11 @@ def get_local_epoch(self, repo_id: str = None):
             max(
                 [
                     int(tag.name.split(".")[1])
+                    for tag in refs.tags
                     if (
-                        (tag.name.split(".") == 3)
+                        (len(tag.name.split(".")) == 3)
                         and (tag.name.split(".")[0] == __run__)
                     )
-                    else int(tag.name)
-                    for tag in refs.tags
                 ]
             )
             if refs.tags
@@ -76,6 +74,33 @@ def get_local_epoch(self, repo_id: str = None):
     except Exception as e:
         bt.logging.warning(f"Error in get_local_epoch: {str(e)}")
         return None
+
+
+def get_local_inner_steps(self, repo_id: str = None):
+    if repo_id is None:
+        repo_id = self.config.neuron.local_model_name
+
+    try:
+        refs = list_repo_refs(repo_id, repo_type="model")
+        local_steps = (
+            max(
+                [
+                    int(tag.name.split(".")[2])
+                    for tag in refs.tags
+                    if (
+                        (len(tag.name.split(".")) == 3)
+                        and (tag.name.split(".")[0] == __run__)
+                        and (tag.name.split(".")[1] == str(self.local_progress.epoch))
+                    )
+                ]
+            )
+            if refs.tags
+            else 0
+        )
+        return local_steps
+    except Exception as e:
+        bt.logging.warning(f"Error in get_local_epoch: {str(e)}")
+        return 0
 
 
 def update_global_tracker_state(self):

--- a/distributed_training/utils/progress_tracker.py
+++ b/distributed_training/utils/progress_tracker.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from distributed_training import __run__
 
 import bittensor as bt
 import pandas as pd
@@ -30,7 +31,17 @@ def get_global_epoch(self):
     try:
         refs = list_repo_refs(self.config.neuron.global_model_name, repo_type="model")
         global_epoch = (
-            max([int(tag.name.split(".")[0]) for tag in refs.tags])
+            max(
+                [
+                    int(tag.name.split(".")[1])
+                    if (
+                        (tag.name.split(".") == 3)
+                        and (tag.name.split(".")[0] == __run__)
+                    )
+                    else int(tag.name)
+                    for tag in refs.tags
+                ]
+            )
             if refs.tags
             else None
         )
@@ -47,7 +58,17 @@ def get_local_epoch(self, repo_id: str = None):
     try:
         refs = list_repo_refs(repo_id, repo_type="model")
         local_epoch = (
-            max([int(tag.name.split(".")[0]) for tag in refs.tags])
+            max(
+                [
+                    int(tag.name.split(".")[1])
+                    if (
+                        (tag.name.split(".") == 3)
+                        and (tag.name.split(".")[0] == __run__)
+                    )
+                    else int(tag.name)
+                    for tag in refs.tags
+                ]
+            )
             if refs.tags
             else None
         )

--- a/distributed_training/utils/state_loader.py
+++ b/distributed_training/utils/state_loader.py
@@ -377,12 +377,16 @@ def load_model_optimizer_gradient_averager(
             use_fast_loader = False  # TODO Set up fall back on using already downloaded model_state/opt_state, if either are missing
 
     if not use_fast_loader:
-        if not check_model_exists(model_name, revision=str(epoch)):
+        if not check_model_exists(
+            model_name, revision=f"{__run__}.{epoch}.{self.local_progress.inner_step}"
+        ):
             model_name = fall_back_model_name
         try:
             self.model = (
                 AutoModelForCausalLM.from_pretrained(
-                    model_name, revision=str(epoch), trust_remote_code=True
+                    model_name,
+                    revision=f"{__run__}.{epoch}.{self.local_progress.inner_step}",
+                    trust_remote_code=True,
                 )
                 if epoch
                 else AutoModelForCausalLM.from_pretrained(
@@ -401,7 +405,7 @@ def load_model_optimizer_gradient_averager(
             self.model = (
                 AutoModelForCausalLM.from_pretrained(
                     model_name,
-                    revision=str(epoch),
+                    revision=f"{__run__}.{epoch}.{self.local_progress.inner_step}",
                     trust_remote_code=True,
                 )
                 if epoch
@@ -459,7 +463,7 @@ def load_model_optimizer_gradient_averager(
                         hf_hub_download(
                             repo_id=model_name,
                             filename="inner_optimizer.pt",
-                            revision=str(epoch),
+                            revision=f"{__run__}.{epoch}.{self.local_progress.inner_step}",
                         ),
                         weights_only=True,
                         map_location="cpu",
@@ -532,14 +536,14 @@ def load_model_optimizer_gradient_averager(
     )
     bt.logging.info("Successfully Loaded State Averager")
 
-    if reload_outer_optimizer:
+    if reload_outer_optimizer and epoch != 0:
         optimizer_state = None
         try:
             optimizer_state = torch.load(
                 hf_hub_download(
                     repo_id=fall_back_model_name,
                     filename="outer_optimizer.pt",
-                    revision=str(epoch),
+                    revision=f"{__run__}.{epoch}.{self.local_progress.inner_step}",
                 ),
                 weights_only=True,
                 map_location="cpu",

--- a/distributed_training/validator/forward.py
+++ b/distributed_training/validator/forward.py
@@ -63,11 +63,6 @@ async def forward(self):
     bt.logging.info(
         f"Current block {self.current_block} | Blocks Since Last AllReduce: {blocks_since_allreduce} | Should AllReduce: {self.should_all_reduce}"
     )
-    # self.state_averager.main_parameters[-3] = "current"
-    # tensor([-9.0812e-07,  1.0692e-06,  8.5682e-07,  ..., -6.6933e-07,
-    #  3.9241e-07,  9.6525e-07], device='cuda:0', requires_grad=True)
-    # self.state_averager.optimizer.param_groups[0]["params"][-3] = "previous_epoch"
-    # tensor([0., 0., 0.,  ..., 0., 0., 0.], requires_grad=True)
 
     responses = [[]]
     self.miner_uids = []

--- a/distributed_training/validator/reward.py
+++ b/distributed_training/validator/reward.py
@@ -17,7 +17,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 import asyncio
-import errno
+import math
 import random
 import time
 from typing import List
@@ -217,7 +217,11 @@ async def score_uid(self, uid: int):
                 )
 
         load_state_from_peer(
-            self, repo_id=model_huggingface_id, epoch=commits[0].commit_id
+            self,
+            repo_id=model_huggingface_id,
+            epoch=commits[0].commit_id,
+            reload_inner_optimizer=True,
+            reload_outer_optimizer=False,
         )
 
         config_final_path = hf_hub_download(
@@ -333,7 +337,9 @@ async def score_uid(self, uid: int):
     self.uid_tracker[uid]["train_number_of_blocks"] += len(blocks)
     self.uid_tracker[uid]["train_duration"] += time_delta
     self.uid_tracker[uid]["train_similarity_score_last_updated"] = time.time()
-    self.uid_tracker[uid]["train_similarity_score"] += scores
+    self.uid_tracker[uid]["train_similarity_score"] += (
+        0 if math.isnan(scores) else scores
+    )
     self.uid_tracker[uid]["train_validation_count"] += 1
     self.uid_tracker[uid]["loss"] = self.local_progress.loss
 

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -313,7 +313,7 @@ class Miner(BaseMinerNeuron):
                     self.config.neuron.local_model_name, repo_type="model"
                 )
                 for tag in refs.tags:
-                    if (tag.name == "None") or (int(tag.name) >= epoch):
+                    if (tag.name == "None") or (int(tag.name.split(".")[0]) >= epoch):
                         # Update tag for this version
                         delete_tag(
                             self.config.neuron.local_model_name,
@@ -325,7 +325,7 @@ class Miner(BaseMinerNeuron):
                 create_tag(
                     self.config.neuron.local_model_name,
                     repo_type="model",
-                    tag=str(epoch),
+                    tag=f"{epoch}.{self.local_progress.inner_step}",
                     tag_message=commit_message,
                 )
                 # Cleanup old cache
@@ -609,6 +609,11 @@ class Miner(BaseMinerNeuron):
                 self.local_progress.epoch += 1
                 self.last_allreduce_block = self.current_block
                 bt.logging.info("AllReduce Operation Finished Succesfully")
+                self.start_background_upload(
+                    epoch=self.local_progress.epoch,
+                    inner_step=self.local_progress.inner_step,
+                    batch_size=self.local_progress.samples_accumulated,
+                )
                 # Resume training when done
                 self.resume_training()
             else:


### PR DESCRIPTION
This PR does the following:

- [x] Sets state averager optimimzer parameters to inner_step 0
- [x] Enables the loading of state based off epoch and inner steps to identify inner_step 0 commit
- [x] Adds run version to a model tag
- [x] Removes the process of deleting historic tags from other runs
- [x] Gets the master validator to upload the scheduler and inner optimiser of the highest ranking miner as the global scheduler and inner optimizer to enable late joiners to catch up
- [x] Forces failed averages to load their latest schedulers and inner optimisers rather than the Globals
- [x] Fixes the bug in all_reduce scores due to relying on local miner model configs rather than the global model config
- [x] Removes the penalty being applied to miners with README.md files in their local repos