### PR TITLE
Address convergence and nan issues

### DIFF
--- a/distributed_training/averaging/avg_handler.py
+++ b/distributed_training/averaging/avg_handler.py
@@ -198,10 +198,16 @@ class AveragingHandler:
 
                 # Update state_avgs main params with inner optimizer params
                 self.update_main_param_after_outer_step()
+                
+                # Zero grads of outer optimizer
+                self.state_averager.optimizer.zero_grad()
 
                 bt.logging.info(
                     ":white_heavy_check_mark: Finished Outer Optimizer Step."
                 )
+                
+                # Clip gradients again
+                torch.nn.utils.clip_grad_norm_(self.model.parameters(), 1.0)
 
                 # Validate weight updates
                 await self._validate_weight_update(initial_weights, block)
@@ -392,11 +398,19 @@ class AveragingHandler:
                 self.state_averager.step(
                     increment_epoch=True, optimizer_step=True, zero_grad=False
                 )
+                
+                # Update state_avgs main params with inner optimizer params
                 self.update_main_param_after_outer_step()
+                
+                # Zero grads of outer optimizer
+                self.state_averager.optimizer.zero_grad()
 
                 bt.logging.info(
                     ":white_heavy_check_mark: Finished Outer Optimizer Step."
                 )
+                
+                # Clip gradients again
+                torch.nn.utils.clip_grad_norm_(self.model.parameters(), 1.0)
 
                 # Validate weight updates
                 await self._validate_weight_update(initial_weights, block)

--- a/distributed_training/utils/config.py
+++ b/distributed_training/utils/config.py
@@ -196,7 +196,7 @@ def add_args(cls, parser, prefix=None):
         "--neuron.local_batch_size_train_effective",
         type=int,
         help="Amount of micro batches for gradient accumulation",
-        default=2048,
+        default=512,
     )
 
     parser.add_argument(

--- a/distributed_training/utils/state_loader.py
+++ b/distributed_training/utils/state_loader.py
@@ -16,7 +16,6 @@ import bittensor as bt
 import hivemind
 import psutil
 import torch
-from memory_profiler import profile
 from datetime import datetime
 
 from hivemind.compression import deserialize_torch_tensor
@@ -32,11 +31,7 @@ from huggingface_hub import (
     scan_cache_dir,
     upload_folder,
 )
-from huggingface_hub.utils import (
-    HfHubHTTPError,
-    RepositoryNotFoundError,
-    EntryNotFoundError,
-)
+from huggingface_hub.utils import HfHubHTTPError
 from huggingface_hub.constants import HF_HUB_CACHE
 from transformers import (
     AutoModelForCausalLM,
@@ -546,8 +541,6 @@ def load_model_optimizer_gradient_averager(
         self.tokenizer,
         self.device,
     )
-
-    self.scaler = torch.amp.GradScaler(enabled=True)
 
     if (self.local_progress.inner_step != 0) and ("." in revision):
         self.state_averager.reset_main_parameters(

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -545,7 +545,7 @@ class Miner(BaseMinerNeuron):
                 outputs = self.model(input_ids=inputs, labels=labels)
                 loss = outputs[1] / self.number_of_local_steps
 
-            self.scaler.scale(loss).backward()
+            loss.backward()
 
             self.running_loss += loss.item() * self.number_of_local_steps
             self.batch_count += 1
@@ -581,9 +581,8 @@ class Miner(BaseMinerNeuron):
 
     def inner_optimizer_step(self):
         torch.nn.utils.clip_grad_norm_(self.model.parameters(), 1.0)
-        self.scaler.unscale_(optimizer=self.inner_optimizer)
-        self.scaler.step(self.inner_optimizer)
-        self.scaler.update()
+        
+        self.inner_optimizer.step()
 
         self.scheduler.step()
 


### PR DESCRIPTION
Does the following:

1. Gradient clip after allreduce to enhance stability of gradients
2. Zero outer optimizer grads to avoid accumulating gradients in the outer optimizer
3. Remove gradscaler as we are training in bfloat16
4. Reduce effective batch size back to 512 as per diloco paper