### PR TITLE
Fix dataloader and blocklist block mismatch

### DIFF
--- a/distributed_training/base/miner.py
+++ b/distributed_training/base/miner.py
@@ -148,9 +148,13 @@ class BaseMinerNeuron(BaseNeuron):
                     # Wait if training is paused
                     self.training_active.wait()
 
+                    self.set_current_block_across_ranks()
+                    block_at_start = self.current_block
+                    self.logger.debug(f"Block passed to dataloader and block list: {block_at_start}")
+
                     self.logger.debug(":pages: Fetching fineweb-edu pages")
                     dataset = self.training_loop.run_until_complete(
-                        self.fetch_training_data()
+                        self.fetch_training_data(block_at_start)
                     )
 
                     # Wait if training is paused
@@ -162,7 +166,7 @@ class BaseMinerNeuron(BaseNeuron):
                     self.training_active.wait()
 
                     if self.master:
-                        self.model.config.block_list.append(self.current_block)
+                        self.model.config.block_list.append(block_at_start)
                     self._process_training_batch(dataset)
 
                 except Exception as e:


### PR DESCRIPTION
Currently, `self.current_block` is updated continuously, causing a mismatch 
between the value passed to `DatasetLoader.next_pages`:

    pages = await DatasetLoader.next_pages(offset=self.current_block)

and the value appended to the model's block_list:

    self.model.config.block_list.append(self.current_block)

First we move `self.set_current_block_across_ranks()` outside of `fetch_training_data` to ensure all ranks have the correct current block before any data loading or training has taken place.

Then we stores `self.current_block` in local variable `block_at_start` so the same value 
is passed to both the dataloader as well as the blocklist, effectively ensuring at later stage that validators are able to retrieve the correct pages miners have trained on.

Expected result:
<img width="1302" height="217" alt="image" src="https://github.com/user-attachments/assets/5f6860bc-7429-4b4d-b349-6df2737ddf87" />
Then confirm eg. in config.json that  `6078993` is in the `block_list`:
`cat config.json `
outputs:
```
  "block_list": [
    6078993,
    6079008
  ],

```
